### PR TITLE
Feature/add precommit hooks fix package name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,15 @@ repos:
             'types-python-dateutil'
         ]
 
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+    -   id: check-toml
+    -   id: check-added-large-files
+
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.9
     hooks:

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ py-projects --version
 
 ### Setup Development Environment
 
+Project requires Python 3.13+ (which is also specified inside [.python-version](.python-version) file) and [uv](https://docs.astral.sh/uv/getting-started/installation/) installed.
+
 ```bash
 
 # Create and activate a virtual environment if needed
@@ -127,10 +129,11 @@ source .venv/bin/activate  # On Unix/macOS
 # Install the package in editable mode with development dependencies
 uv pip install --editable ".[dev]"
 
-py-projects
+# Check the installed package
+py-projects --version
 
 # (Optional) Setup Pre-Commit Hook
-uvx --with-editable .pre-commit install
+uvx --with-editable . pre-commit install
 
 # Run development tools directly (no need for 'uv pip run')
 pytest
@@ -248,6 +251,20 @@ Python line length standards:
 - 100: Google's choice. Popular in enterprise. Good for complex expressions.
 - 120: Maximum reasonable length. Works on wide screens but can hurt readability.
 - Recommendation: Use 88 characters (Black's default) unless your team/project has an existing standard. It offers the best balance of readability and practicality while following modern community practices.
+
+## Ruff 
+Ruff is a high-performance linter and code formatter for Python. It combines multiple tools into one, offering faster performance and comprehensive functionality compared to traditional Python tools.
+
+Pros:
+
+- Very Fast: Written in Rust, Ruff is significantly faster than traditional linters, allowing it to process large codebases quickly.
+- All-in-One Solution: Ruff incorporates checks and fixes from a variety of popular linters like Flake8, Black, isort, pydocstyle, pyupgrade, autoflake. This means less maintenance of multiple separate tools.
+- Customizable: Allows users to select and ignore specific checks or enforce particular rules according to the project needs.
+- Easy Integration: Works well with CI/CD pipelines, IDEs, and modern developer workflows.
+Automated Fixes: Ruff can automatically correct a wide range of issues in your code.
+
+Cons:
+- Relatively New: As a newer tool, it might not yet be as widely adopted or supported in some edge cases.
 
 ## mypy
 Most teams today actually run both mypy and pyright/Pylance:

--- a/py_launch_blueprint/__init__.py
+++ b/py_launch_blueprint/__init__.py
@@ -2,6 +2,6 @@
 
 from importlib import metadata
 
-__version__ = metadata.version("py-utils")
+__version__ = metadata.version("py_launch_blueprint")
 
 from .projects import main  # Re-export main function

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "py_launch_blueprint"
 version = "0.1.0"
 description = "CLI tools for interacting with Py, including project search functionality"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "MIT"
 authors = [
     { name = "Steve Morin", email = "steve.morin@gmail.com" }


### PR DESCRIPTION
What's new in this PR

1. Added following important pre-commit hooks
- check-yaml
- end-of-file-fixer
- trailing-whitespace
- check-toml
- check-added-large-files
2. Added instruction to have Python 3.13+ and uv installed
3. Added Introduction for Ruff.
4. Fixed the package name, which was introducing errors to run some of the commands in the instruction