### PR TITLE
Update update-contributors.yml

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: main  
       
       - name: Setup Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
This ensures that the GitHub action downloads the code on the main branch and not in a "detached HEAD" state. This is for the uncheck in Sonar associated to "Create Pull Request".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced our automation processes by explicitly referencing the primary branch during workflow execution, ensuring more consistent operations behind the scenes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->