### PR TITLE
Update update-contributors.yml

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: main  
-      
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -29,6 +29,11 @@ jobs:
         run: |
           python update_contributors.py
 
+      - name: Ensure on a branch and push
+        run: |
+          git checkout -B update-contributors
+          git push origin update-contributors || true 
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
@@ -36,4 +41,5 @@ jobs:
           title: 'chore: update contributors list'
           body: 'Automatically updated contributors list using Git log'
           branch: update-contributors
+          base: main  # Especificar base para evitar problemas
           delete-branch: true


### PR DESCRIPTION
Resolve the error that occurs because git reset --hard origin/update-contributors is trying to reset a branch that doesn't exist on GitHub. We must force the branch to be created and submitted correctly.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes branch existence issue in `update-contributors.yml` by ensuring `update-contributors` branch is created before pushing.
> 
>   - **Workflow Changes**:
>     - In `.github/workflows/update-contributors.yml`, added a step to ensure the `update-contributors` branch exists before pushing.
>     - Modified the `git` command to `git checkout -B update-contributors` to create or switch to the branch.
>     - Added `git push origin update-contributors || true` to handle cases where the branch doesn't exist remotely.
>   - **Pull Request Creation**:
>     - Specified `base: main` in the `create-pull-request` step to avoid issues with the base branch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=smorin%2Fpy-launch-blueprint&utm_source=github&utm_medium=referral)<sup> for 23ae48b6f0248322c455bf289be962094e0bae79. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced the automation process for updating contributor information by introducing improved branch management and error-tolerant operations.
	- Now explicitly specifies the target branch during pull request creation to boost overall workflow reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->