### PR TITLE
ci: fix `security` job blank secret on forked PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ name: CI/CD
 on:
   push:
     branches: [ main ]
-  pull_request:
+  pull_request_target:
     branches: [ main ]
 
 jobs:
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ name: CI/CD
 on:
   push:
     branches: [ main ]
-  pull_request_target:
+  pull_request:
     branches: [ main ]
 
 jobs:
@@ -17,8 +17,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5
@@ -49,16 +47,8 @@ jobs:
 #    - name: Upload coverage
 #      uses: codecov/codecov-action@v4
 
-  security:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Run Safety CLI to check for vulnerabilities
-      uses: pyupio/safety-action@v1
-      with:
-        api-key: ${{ secrets.SAFETY_API_KEY }}
-        args: --detailed-output # To always see detailed output from this action
+    - name: Scan for vulnerabilities
+      uses: paulfermoreyes/py-launch-blueprint@main
 
   # publish:
   #   needs: [test, security]

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,15 @@
+name: Security
+on:
+  workflow_call:
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Safety CLI to check for vulnerabilities
+        uses: pyupio/safety-action@v1
+        with:
+          api-key: ${{ secrets.SAFETY_API_KEY }}
+          args: --detailed-output # To always see detailed output from this action


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Separated `security` job into `security.yaml` to improve secret handling in forked PRs.
> 
>   - **CI Workflow Changes**:
>     - Removed `security` job from `ci.yaml`.
>     - Added `security.yaml` for the `security` job, which runs on `ubuntu-latest` and uses `pyupio/safety-action@v1` with `SAFETY_API_KEY`.
>   - **Security Job**:
>     - The `security` job now runs independently, improving handling of secrets in forked PRs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=smorin%2Fpy-launch-blueprint&utm_source=github&utm_medium=referral)<sup> for 96bbb927687b5a9c5251a1d6a1cbbd62960981ba. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced our CI/CD workflow to ensure pull request tests run against the precise commit submitted, improving build reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->