### PR TITLE
Updates documentation formats

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,4 +30,6 @@ python:
         - docs
 
 formats:
-  - all
+  - pdf
+  - epub
+  - htmlzip


### PR DESCRIPTION
Changes the documentation formats to include PDF, EPUB, and HTMLZIP instead of "all" which isn't valid and causes and error.

This provides users with a wider range of options for accessing the documentation.

Closes bug #119 Readthedocs broken
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates `.readthedocs.yaml` to specify valid documentation formats, fixing Readthedocs configuration error.
> 
>   - **Configuration**:
>     - Updates `formats` in `.readthedocs.yaml` from `all` to `pdf`, `epub`, and `htmlzip`.
>   - **Bug Fix**:
>     - Fixes bug #119 related to Readthedocs configuration error due to invalid format specification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=smorin%2Fpy-launch-blueprint&utm_source=github&utm_medium=referral)<sup> for 94bab20591994861d8ce94fc2052f6af81ffd698. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the documentation build to generate outputs in PDF, EPUB, and HTML ZIP formats for improved clarity and control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->