### PR TITLE
 fix ruff-format ignore the auto-generated version.py file(228)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ max-line-length = 88
 "tests/*" = ["S101", "S105", "S106"] # Ignore assert statements in tests
 "py_launch_blueprint/_version.py" = [
     "ALL",
-] # Ignore all Ruff checks for version.py
+] # Ignore all Ruff checks for version.py file
 # S101: This check flags the use of assert statements. The reason is that assert statements are removed when Python code is optimized (run with the -O flag), which can lead to security vulnerabilities if assert is used for security checks.
 # S105: This generally flags hardcoded password strings in code.
 # S106: This generally flags hardcoded password variables in code.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,17 @@
 [project]
 name = "py_launch_blueprint"
-dynamic = ["version"]  #make version dynamic
+dynamic = ["version"] #make version dynamic
 description = "CLI tools for interacting with Py, including project search functionality"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
-authors = [
-    { name = "Steve Morin", email = "steve.morin@gmail.com" }
-]
+authors = [{ name = "Steve Morin", email = "steve.morin@gmail.com" }]
 dependencies = [
     "click>=8.1.0",
     "questionary>=2.0.0",
     "python-dotenv>=1.0.0",
     "thefuzz>=0.19.0",
-    "python-Levenshtein>=0.21.0",  # For better performance with thefuzz
+    "python-Levenshtein>=0.21.0", # For better performance with thefuzz
     "pyperclip>=1.8.0",
     "requests>=2.31.0",
     "rich>=13.0.0",
@@ -28,7 +26,7 @@ dev = [
     "pre-commit>=4.1.0",
     "types-requests",
     "types-Pygments",
-    "cogapp"
+    "cogapp",
 ]
 
 docs = [
@@ -40,7 +38,7 @@ docs = [
     "cogapp",
     "sphinx-copybutton",
     "sphinx-autobuild",
-    "sphinxext-opengraph", # https://github.com/wpilibsuite/sphinxext-opengraph
+    "sphinxext-opengraph",      # https://github.com/wpilibsuite/sphinxext-opengraph
 ]
 
 
@@ -48,7 +46,7 @@ docs = [
 py-projects = "py_launch_blueprint.projects:main"
 
 [build-system]
-requires = ["hatchling","hatch-vcs", "setuptools>=64", "setuptools-scm>=8"]
+requires = ["hatchling", "hatch-vcs", "setuptools>=64", "setuptools-scm>=8"]
 build-backend = "hatchling.build"
 
 [tool.setuptools_scm]
@@ -83,7 +81,7 @@ lint.ignore = [
 
 # Allow autofix behavior for specific rules
 fix = true
-lint.unfixable = []  # Rules that should not be fixed automatically
+lint.unfixable = [] # Rules that should not be fixed automatically
 
 # Exclude files/folders
 exclude = [
@@ -92,7 +90,7 @@ exclude = [
     "__pycache__",
     "build",
     "dist",
-    "docs/source/conf.py"
+    "docs/source/conf.py",
 ]
 
 [tool.ruff.pycodestyle]
@@ -100,8 +98,11 @@ max-line-length = 88
 
 # Per-file-ignores
 [tool.ruff.lint.per-file-ignores]
-"__init__.py" = ["F401"]  # Ignore unused imports in __init__.py files
-"tests/*" = ["S101", "S105", "S106"]      # Ignore assert statements in tests
+"__init__.py" = ["F401"] # Ignore unused imports in __init__.py files
+"tests/*" = ["S101", "S105", "S106"] # Ignore assert statements in tests
+"py_launch_blueprint/_version.py" = [
+    "ALL",
+] # Ignore all Ruff checks for version.py
 # S101: This check flags the use of assert statements. The reason is that assert statements are removed when Python code is optimized (run with the -O flag), which can lead to security vulnerabilities if assert is used for security checks.
 # S105: This generally flags hardcoded password strings in code.
 # S106: This generally flags hardcoded password variables in code.
@@ -163,9 +164,4 @@ local_scheme = "no-local-version" # No commit ID or dirty flag
 packages = ["py_launch_blueprint"]
 
 [tool.hatch.build.targets.sdist]
-include = [
-    "py_launch_blueprint",
-    "docs",
-    "pyproject.toml",
-    "README.md",
-]
+include = ["py_launch_blueprint", "docs", "pyproject.toml", "README.md"]


### PR DESCRIPTION
# Feature Pull Request

Current branch: `bug/ignore-ruff-format-version-file`

## Related Issue
<!-- IMPORTANT: Please verify this issue number is correct and exists -->
<!-- Use the format: Closes #123 or Fixes #123 to automatically close the issue when this PR is merged -->
Closes #228 

## Feature Description

Currently, ruff-format is changing the auto-generated **version.py** file, and there is no need for that.


## Implementation Details

Add a ignore check in pyproject.toml file to ignore ruff formatting for **version.py** file.

## Changes Made

Update the **pyproject.toml** file  and add Ignore all Ruff checks for **version.py**

1: Now CI/CD / Update Contributors / workflow] already fixed in separate PR https://github.com/smorin/py-launch-blueprint/issues/171.


## Testing Performed

1. Manually test ruff is ignoring the **version.py** file.
2. And passing in pre-commit-run

## Testing Instructions
1: By the check ruff command
```bash
 ruff check py_launch_blueprint/_version.py
 ```

2: Test by running pre-commit
```bash
 just pre-commit-run
 ```



## Documentation Updates

 N/A


## Checklist
<!-- Please verify each item by checking the box -->
- [x] Branch name follows convention (`feature/description` or `feature/issue-number-description`)
- [x] Testing added to pre-commit hook (`pre-commit run --all-files` passes)
- [ ] Testing added to CI/CD pipeline in GitHub Actions
- [ ] Documentation added/updated in Sphinx
- [ ] Appropriate unit test coverage added (run `pytest --cov` to verify)
- [ ] New commands added to CLI (if applicable)
- [ ] Code follows project style guidelines (`flake8` or equivalent passes)
- [ ] All tests pass locally and in CI
- [x] Self-review of code performed
- [ ] No debug print statements or commented-out code left in the codebase

## Reviewer Notes
<!-- Any specific areas that need careful review or explanation -->
<!-- Highlight complex parts or areas where you're seeking feedback -->
<!-- Example:
- The authentication flow in auth_service.py:125-150 is complex and needs careful review
- The database migration might need performance review for large datasets
- Security review needed for the token generation logic
-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update `pyproject.toml` to ignore Ruff checks for `version.py`.
> 
>   - **Configuration**:
>     - Update `pyproject.toml` to ignore all Ruff checks for `py_launch_blueprint/_version.py`.
>   - **Testing**:
>     - Manually verified Ruff ignores `version.py`.
>     - Confirmed passing in pre-commit run.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=smorin%2Fpy-launch-blueprint&utm_source=github&utm_medium=referral)<sup> for 5e5c1a250855bf051342218cf56d2b720e56020d. You can [customize](https://app.ellipsis.dev/smorin/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved formatting and consistency in configuration settings, including spacing, array formatting, and trailing commas.
- **Chores**
  - Updated linter settings to exclude linting for the generated version file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->