### PR TITLE
CI/CD exception for changelog and contributors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,8 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11"]
-
+     # Skip this job if commit message contains the automated commit signature to avoid loops
+    if: "!contains(github.event.head_commit.message, 'ci: update changelog and contributors')"
     steps:
     - uses: actions/checkout@v4
 
@@ -50,13 +51,13 @@ jobs:
        just pre-commit-run
 
     # You can uncomment the following if you want to run tests with coverage
-    # - name: Run tests with coverage
-    #   run: |
-    #     pytest --cov=./ --cov-report=xml
+    - name: Run tests with coverage
+      run: |
+          pytest --cov=./ --cov-report=xml
 
     # Upload coverage (if tests are being run)
-    # - name: Upload coverage
-    #   uses: codecov/codecov-action@v4
+    - name: Upload coverage
+      uses: codecov/codecov-action@v4
 
   # Only run security checks on pull requests from the main repository
   security:
@@ -70,7 +71,47 @@ jobs:
       with:
         api-key: ${{ secrets.SAFETY_API_KEY }}
         args: --detailed-output # To always see detailed output from this action
+ # New job: Update changelog and contributors after tests succeed
+  update-changelog-and-contributors:
+    name: Update changelog and contributors
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.ref == 'refs/heads/main' && success()
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0  # Needed to push commits
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Cocogitto and dependencies
+        run: |
+          pip install cocogitto
+
+      - name: Update changelog
+        run: |
+          cocogitto changelog --yes
+
+      - name: Update CONTRIBUTORS.md
+        run: |
+          # Replace this with your actual contributors update script
+          ./scripts/update_contributors.sh
+
+      - name: Commit and push changes if any
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md CONTRIBUTORS.md
+          if ! git diff --cached --quiet; then
+            git commit -m "ci: update changelog and contributors"
+            git push origin main
+          else
+            echo "No changelog or contributors updates to commit."
+          fi
   # The publish job is commented out, but here's a reference if you want to re-enable it
   # publish:
   #   needs: [test, security]

--- a/scripts/update_changelog.sh
+++ b/scripts/update_changelog.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+# Generate or update the changelog at the current HEAD using cog
+cog changelog --at HEAD

--- a/scripts/update_contributors.sh
+++ b/scripts/update_contributors.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+# Temporary file for contributors list
+TMP_FILE=$(mktemp)
+
+# Extract unique contributor names excluding bots
+git log --format='%aN' | \
+  grep -v -i 'github-actions\[bot\]' | \
+  sort -u > "$TMP_FILE"
+
+# Normalize contributor names (example)
+sed -i 's/Tatiana H./Tatiana Hernández/g' "$TMP_FILE"
+
+# Write header and contributors to CONTRIBUTORS.md
+{
+  echo "# Contributors"
+  echo
+  cat "$TMP_FILE"
+} > CONTRIBUTORS.md
+
+# Clean up temporary file
+rm "$TMP_FILE"
+
+echo "CONTRIBUTORS.md updated successfully."


### PR DESCRIPTION
# Feature Pull Request

## Branch Naming Convention
`CI/CD-exception-for-changelog-and-contributors
`
## Related Issue
<!-- IMPORTANT: Please verify this issue number is correct and exists -->
<!-- Use the format: Closes #123 or Fixes #123 to automatically close the issue when this PR is merged -->
Closes #232 

## Feature Description
This PR implements a controlled CI/CD mechanism to allow automated updates for the CHANGELOG.md and CONTRIBUTORS.md files. These exceptions are safeguarded to ensure they occur only after all critical CI jobs (tests, lint, type checks) pass. This prevents premature commits and avoids infinite CI loops.

## Implementation Details

1. Added a new job update-changelog-and-contributors in .github/workflows/ci.yaml that:
- Runs only on the main branch and after the test job succeeds (needs: test)
- Commits and pushes changes only if actual updates are detected

2. Introduced scripts/update_contributors.sh to auto-generate CONTRIBUTORS.md:
- Extracts contributors from Git history
- Excludes bots and normalizes known aliases

3. Introduced scripts/update_changelog.sh as a helper wrapper around cog changelog --at HEAD

Changes Made

## Changes Made

1. Modified .github/workflows/ci.yaml:
- Added a job for post-success updates of changelog and contributors list
- Ensured the job runs only on main and after tests
2. Created scripts/update_contributors.sh
3. Created scripts/update_changelog.sh

## Testing Performed

1. Manual testing of .github/workflows/ci.yaml logic:
- Verified changelog/contributors only update after CI passes
- Confirmed no push occurs when there are no updates

2. Local Testing:

- Ran both scripts manually
- Confirmed expected changes to CONTRIBUTORS.md and CHANGELOG.md

## Pre-commit and Testing Instructions
<!-- Follow these steps to run pre-commit hooks and tests before submitting -->

**Running Pre-commit Hooks:**
```bash
# These are basic defaults for testing.
# Please adjust as needed for complete testing of your changes

# Install pre-commit if not already installed
just pre-commit-setup

# Run pre-commit on all files
just pre-commit-run
```

**Running Tests:**
```bash
# Run all tests
just test
# Note: The `just test` command is a project-specific command for running tests.
# Please refer to the project documentation or the CONTRIBUTING.md file for setup instructions.
```

-->

## Documentation Updates
<!-- Describe any documentation changes made or needed -->
<!-- Include updates to Sphinx docs, README, etc. -->
<!-- Example:
- Updated authentication section in docs/usage.md
- Added new docs/auth.md file with detailed API documentation
- Updated README.md with new authentication instructions
- Added docstrings to all new classes and methods
-->

## Breaking Changes
<!-- List any backwards-incompatible changes this PR introduces -->
<!-- If none, state "None" -->
<!-- Example: The config format has changed, existing config files need to be updated following the migration guide in docs/migrations.md -->

## Checklist
<!-- Please verify each item by checking the box -->
- [ ] Branch name follows convention (`feature/description` or `feature/issue-number-description`)
- [ ] Testing added to pre-commit hook (`pre-commit run --all-files` passes)
- [ ] Testing added to CI/CD pipeline in GitHub Actions
- [ ] Documentation added/updated in Sphinx
- [ ] Appropriate unit test coverage added (run `pytest --cov` to verify)
- [ ] New commands added to CLI (if applicable)
- [ ] Code follows project style guidelines (`flake8` or equivalent passes)
- [ ] All tests pass locally and in CI
- [ ] Self-review of code performed
- [ ] No debug print statements or commented-out code left in the codebase

## Reviewer Notes
<!-- Any specific areas that need careful review or explanation -->
<!-- Highlight complex parts or areas where you're seeking feedback -->
<!-- Example:
- The authentication flow in auth_service.py:125-150 is complex and needs careful review
- The database migration might need performance review for large datasets
- Security review needed for the token generation logic
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds CI/CD job to update `CHANGELOG.md` and `CONTRIBUTORS.md` post-successful tests, with new scripts for automation.
> 
>   - **CI/CD Workflow**:
>     - Adds `update-changelog-and-contributors` job in `.github/workflows/ci.yaml` to run on `main` after tests pass.
>     - Job commits and pushes changes to `CHANGELOG.md` and `CONTRIBUTORS.md` if updates are detected.
>   - **Scripts**:
>     - `scripts/update_contributors.sh`: Generates `CONTRIBUTORS.md` from Git history, excluding bots, and normalizes names.
>     - `scripts/update_changelog.sh`: Updates `CHANGELOG.md` using `cog` at current HEAD.
>   - **Misc**:
>     - Prevents CI loops by skipping jobs if commit message contains 'ci: update changelog and contributors'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=smorin%2Fpy-launch-blueprint&utm_source=github&utm_medium=referral)<sup> for 9c1d86d8b04771e58d7ef05405fdfab21baa3710. You can [customize](https://app.ellipsis.dev/smorin/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Automated updates of the changelog and contributors list after successful tests on the main branch.
	- Added scripts to generate and update the changelog and CONTRIBUTORS.md file automatically.
	- Improved CI workflow to prevent infinite loops from automated commits and enabled test coverage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->