### PR TITLE
Fix typo in type checking documentation

### DIFF
--- a/docs/source/tasks/type_checking_code.md
+++ b/docs/source/tasks/type_checking_code.md
@@ -13,7 +13,7 @@ To set up MyPy for your project, follow these steps:
    ```
 
 2. **Configure MyPy**:
-   check in the [`myproject.toml`](https://github.com/smorin/py-launch-blueprint/blob/main/pyproject.toml) file the [tool.mypy] section
+   check in the [`pyproject.toml`](https://github.com/smorin/py-launch-blueprint/blob/main/pyproject.toml) file the [tool.mypy] section
 
 3. **Run MyPy**:
    To check your code with MyPy, run the following command:


### PR DESCRIPTION
- Corrected 'myproject.toml' to 'pyproject.toml' in docs/source/tasks/type_checking_code.md.

@copilot please update the PR description
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects 'myproject.toml' to 'pyproject.toml' in `type_checking_code.md` for accurate MyPy setup instructions.
> 
>   - **Documentation**:
>     - Corrected 'myproject.toml' to 'pyproject.toml' in `type_checking_code.md` to accurately reflect the configuration file name for MyPy setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=smorin%2Fpy-launch-blueprint&utm_source=github&utm_medium=referral)<sup> for 51f0576737ee310712574977ccc2dc2cb9d23d40. You can [customize](https://app.ellipsis.dev/smorin/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected references to the configuration file, specifying `pyproject.toml` instead of `myproject.toml` in the MyPy setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->