### PR TITLE
fix: tighten pypirc gitleaks allowlist

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -6,18 +6,21 @@ useDefault = true
 [[allowlists]]
 description = "Repository placeholders and generated documentation examples"
 
-paths = [
-  '''(^|/)analysis/''',
-  '''(^|/)docs/''',
-  '''\.gitleaks\.toml$''',
-  '''\.pypirc\.template$''',
-]
+paths = ['''(^|/)analysis/''', '''(^|/)docs/''', '''\.gitleaks\.toml$''']
 
 regexes = [
   '''REPLACE_WITH_[A-Z0-9_]+''',
   '''YOUR_[A-Z0-9_]+''',
   '''xxxxxxxx+''',
 ]
+
+[[allowlists]]
+description = "Expected PyPI token placeholders in .pypirc.template"
+condition = "AND"
+
+paths = ['''(^|/)\.pypirc\.template$''']
+
+regexes = ['''REPLACE_WITH_PYPI_TOKEN''', '''REPLACE_WITH_TESTPYPI_TOKEN''']
 
 [[allowlists]]
 description = "Test-file placeholder/mock/example tokens"

--- a/tests/test_project_infrastructure.py
+++ b/tests/test_project_infrastructure.py
@@ -110,3 +110,18 @@ def test_onboarding_and_secret_files_are_template_safe() -> None:
     assert "just check" in agents
     assert "doxa" not in agents.lower()
     assert re.search(r"\[extend\]\s+useDefault = true", gitleaks)
+
+
+def test_pypirc_template_is_not_whole_file_secret_scan_allowlisted() -> None:
+    gitleaks = read(".gitleaks.toml")
+    pypirc_allowlists = [
+        block
+        for block in gitleaks.split("[[allowlists]]")
+        if "pypirc" in block and "template" in block
+    ]
+
+    assert pypirc_allowlists
+    for block in pypirc_allowlists:
+        assert 'condition = "AND"' in block
+        assert "REPLACE_WITH_PYPI_TOKEN" in block
+        assert "REPLACE_WITH_TESTPYPI_TOKEN" in block

--- a/tests/test_project_infrastructure.py
+++ b/tests/test_project_infrastructure.py
@@ -114,14 +114,29 @@ def test_onboarding_and_secret_files_are_template_safe() -> None:
 
 def test_pypirc_template_is_not_whole_file_secret_scan_allowlisted() -> None:
     gitleaks = read(".gitleaks.toml")
-    pypirc_allowlists = [
-        block
-        for block in gitleaks.split("[[allowlists]]")
-        if "pypirc" in block and "template" in block
-    ]
+    allowlist_blocks = gitleaks.split("[[allowlists]]")[1:]
 
-    assert pypirc_allowlists
-    for block in pypirc_allowlists:
-        assert 'condition = "AND"' in block
-        assert "REPLACE_WITH_PYPI_TOKEN" in block
-        assert "REPLACE_WITH_TESTPYPI_TOKEN" in block
+    pypirc_path_needle = r"\.pypirc\.template$"
+    blocks_with_pypirc_path = [
+        block for block in allowlist_blocks if pypirc_path_needle in block
+    ]
+    assert len(blocks_with_pypirc_path) == 1, (
+        "`.pypirc.template` must appear in exactly one allowlist `paths` entry; "
+        f"found {len(blocks_with_pypirc_path)}"
+    )
+
+    dedicated = blocks_with_pypirc_path[0]
+    assert 'condition = "AND"' in dedicated
+    assert "REPLACE_WITH_PYPI_TOKEN" in dedicated
+    assert "REPLACE_WITH_TESTPYPI_TOKEN" in dedicated
+
+    forbidden_broad_regexes = [
+        "REPLACE_WITH_[A-Z0-9_]+",
+        "YOUR_[A-Z0-9_]+",
+        "xxxxxxxx+",
+    ]
+    for pattern in forbidden_broad_regexes:
+        assert pattern not in dedicated, (
+            f"dedicated `.pypirc.template` allowlist must not contain broad "
+            f"pattern {pattern!r}"
+        )


### PR DESCRIPTION
## Summary
- Moves `.pypirc.template` out of the broad documentation/placeholder allowlist into its own dedicated allowlist with `condition = "AND"`, so only `REPLACE_WITH_PYPI_TOKEN` and `REPLACE_WITH_TESTPYPI_TOKEN` are excused inside that file (rather than every regex in the broad list).
- Adds `test_pypirc_template_is_not_whole_file_secret_scan_allowlisted` as a regression guard so the file can't be wholesale-allowlisted again.

## Context
Recovered from a previously-deleted branch (`implement-must-do-uv-build`); the original PR #306 squash-merged the must-do infrastructure, but this follow-up commit had been pushed to the branch after that merge and was not part of #306.

## Test plan
- [x] `uvx --with-editable . pytest tests/test_project_infrastructure.py` (7 passed locally)
- [ ] CI green on the PR