### PR TITLE
feat: integrate codecov for coverage reporting (adapted from #301)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,17 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+comment:
+  layout: "reach,diff,flags,footer"
+  behavior: default
+  require_changes: true
+
+flags:
+  unittests:
+    paths:
+      - tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,18 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Sync dev env
         run: uv sync --group dev  # PEP 735 (ITM-063)
-      - name: Run tests
+      - name: Run tests with coverage
         # Default skips slow/live markers (ITM-046 addopts); CI runs everything.
-        run: uv run pytest -m ""
+        run: uv run pytest -m "" --cov=py_launch_blueprint --cov-report=xml
+      - name: Upload coverage to Codecov
+        # Single matrix combo uploads (avoids 4x duplicate reports).
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          flags: unittests
+          fail_ci_if_error: false
 
   # Taplo (TOML formatter check) kept here for now; ITM-066 will fold into
   # justfile + add a dedicated workflow if needed.

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ wheels/
 *.egg-info
 .ropeproject
 .coverage
+coverage.xml
+htmlcov/
 docs/build/
 .DS_Store
 

--- a/Justfile
+++ b/Justfile
@@ -157,6 +157,17 @@ alias tc := typecheck
 
 alias t := test
 
+# Run tests with coverage and generate term-missing + HTML + XML reports
+[group('test'), group('dev')]
+@coverage:
+    uv run pytest --cov=py_launch_blueprint --cov-report=term-missing --cov-report=html --cov-report=xml
+    echo "Coverage report at htmlcov/index.html"
+
+# Open the local HTML coverage report (macOS: open / Linux: xdg-open)
+[group('test'), group('dev')]
+@open-coverage-report:
+    if command -v open >/dev/null 2>&1; then open htmlcov/index.html; else xdg-open htmlcov/index.html; fi
+
 # Run all checks
 [group('test'), group('dev'), group('quick start')]
 @check: test lint typecheck check-yaml check-spelling check-editorconfig

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/py-launch-blueprint.svg)](https://pypi.org/project/py-launch-blueprint/)
 [![Python versions](https://img.shields.io/pypi/pyversions/py-launch-blueprint.svg)](https://pypi.org/project/py-launch-blueprint/)
 [![CI](https://github.com/smorinlabs/py-launch-blueprint/actions/workflows/ci.yml/badge.svg)](https://github.com/smorinlabs/py-launch-blueprint/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/smorinlabs/py-launch-blueprint/branch/main/graph/badge.svg)](https://codecov.io/gh/smorinlabs/py-launch-blueprint)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)

--- a/docs/source/tools/code-cov.md
+++ b/docs/source/tools/code-cov.md
@@ -1,0 +1,82 @@
+# Codecov Integration
+
+[Codecov](https://about.codecov.io/) provides hosted code-coverage reporting integrated with GitHub. This project uploads coverage from CI so each pull request gets a coverage delta and the README badge stays current.
+
+## What is integrated
+
+- **`pytest-cov`** runs alongside the test suite in the `test` job of `.github/workflows/ci.yml`.
+- **`codecov/codecov-action@v5`** uploads `coverage.xml` from a single matrix combo (`ubuntu-latest` / Python 3.12) to avoid duplicate reports.
+- **`.codecov.yml`** at the repo root configures precision, badge color range (70–100), and PR comment behavior.
+- **`just coverage`** runs the same coverage locally and writes `htmlcov/` for browser inspection.
+
+## Running coverage locally
+
+```bash
+just coverage              # term + html + xml reports
+just open-coverage-report  # open htmlcov/index.html
+```
+
+`coverage.xml` and `htmlcov/` are git-ignored.
+
+## CI configuration
+
+The coverage upload step is gated to one matrix combo:
+
+```yaml
+- name: Upload coverage to Codecov
+  if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+  uses: codecov/codecov-action@v5
+  with:
+    token: ${{ secrets.CODECOV_TOKEN }}
+    files: coverage.xml
+    flags: unittests
+    fail_ci_if_error: false
+```
+
+`fail_ci_if_error: false` keeps a Codecov outage from blocking a merge.
+
+## Required setup (one-time per repo)
+
+1. Add the repo on [codecov.io](https://app.codecov.io).
+2. Copy the repository upload token from Codecov settings.
+3. Add it to GitHub repo settings → **Secrets and variables → Actions** as `CODECOV_TOKEN`.
+
+For public repos, the token is technically optional but recommended (improves rate-limit behavior).
+
+## Configuration reference
+
+The `.codecov.yml` at the repo root:
+
+```yaml
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+comment:
+  layout: "reach,diff,flags,footer"
+  behavior: default
+  require_changes: true
+
+flags:
+  unittests:
+    paths:
+      - tests/
+```
+
+- `range: "70...100"` only affects the badge color (red below 70, yellow 70–100, green at 100). It does **not** fail CI.
+- `comment.require_changes: true` keeps Codecov from commenting on PRs where coverage is unchanged.
+
+## Disabling
+
+- **Temporarily:** comment out the `Upload coverage to Codecov` step in `.github/workflows/ci.yml`.
+- **Permanently:** remove that step, delete `.codecov.yml`, remove the README badge, and remove `CODECOV_TOKEN` from repo secrets.
+
+## References
+
+- [Codecov docs](https://docs.codecov.com/)
+- [`codecov/codecov-action`](https://github.com/codecov/codecov-action)
+- [`pytest-cov`](https://pytest-cov.readthedocs.io/)

--- a/docs/source/tools/index.md
+++ b/docs/source/tools/index.md
@@ -16,6 +16,7 @@ Welcome to the Tools section of the Py Launch Blueprint documentation. This sect
 - [Justfiles](justfiles.md)
 - [precommit_hooks](precommit_hooks.md)
 - [CLA Assistant](cla-assistant.md)
+- [Codecov](code-cov.md)
 
 Each of these sections contains detailed instructions and best practices to help you effectively use the tools in your development workflow.
 
@@ -34,5 +35,6 @@ vs_code
 makefiles
 justfiles
 cla-assistant
+code-cov
 
 ```


### PR DESCRIPTION
## Summary
Adapts #301 (credit: @husnain067) to fit the synthesis-impl toolchain. The original could not be merged as-is because it modified the pre-synthesis monolithic `.github/workflows/ci.yaml` (now split per-job), referenced a stale `smorin/...` codecov URL, and used inconsistent `codecov-action` versions.

## What's in it
- **`.codecov.yml`** at repo root — precision, 70–100 badge range, PR comment policy with `require_changes: true`
- **`.github/workflows/ci.yml`** `test` job — runs `pytest --cov=py_launch_blueprint --cov-report=xml` and uploads `coverage.xml` to Codecov via `codecov-action@v5` from **one** matrix combo (`ubuntu-latest` / py3.12) to avoid duplicate reports
- **Justfile** — `coverage` and `open-coverage-report` recipes for local use
- **README** — codecov badge with the correct `smorinlabs/` URL
- **`docs/source/tools/code-cov.md`** + entry in `docs/source/tools/index.md`
- **`.gitignore`** — `coverage.xml`, `htmlcov/`

`pytest-cov` was already in `[dependency-groups].dev`; no `pyproject.toml` change needed.

## One-time setup before this is fully functional
- Add the repo on [codecov.io](https://app.codecov.io)
- Add `CODECOV_TOKEN` to repo secrets (Settings → Secrets and variables → Actions)

Until that token is set, the upload step will run with `fail_ci_if_error: false` and silently no-op — it won't block PRs.

## Verification (local)
- `uv run pytest --cov=py_launch_blueprint --cov-report=xml` — **19/19 pass**, **86% coverage** (`__init__.py` 100%, `projects.py` 86%)
- `uvx ruff check .` — clean
- `uvx ruff format --check .` — clean
- `uvx yamllint -c .yamllint .github/workflows/ci.yml .codecov.yml` — clean (exit 0)

## Closes
- #301 (superseded by this PR)