### PR TITLE
perf(ci): swap taplo install from cargo build to pre-built binary (~40x faster)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,16 +87,13 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      # taiki-e/install-action downloads a pre-built taplo binary directly
-      # from the upstream GitHub release (no cargo compile). ~1-3s installed
-      # vs ~2min for the previous `cargo install taplo-cli` path. The action
-      # also caches the binary across runs (key includes runner OS + version).
-      # Local dev: see `just install-taplo` — Justfile recipe uses the same
-      # upstream binary directly (curl + gunzip), so both CI and local paths
-      # get the same speedup.
+      - name: Install just
+        uses: extractions/setup-just@v4
+      # `just install-taplo` now downloads the upstream pre-built binary
+      # (curl + gunzip from https://github.com/tamasfe/taplo/releases) —
+      # ~1-3s installed vs the prior ~2min `cargo install taplo-cli`. Same
+      # path as local dev; no external installer action needed.
       - name: Install taplo
-        uses: taiki-e/install-action@v2
-        with:
-          tool: taplo-cli
+        run: just install-taplo
       - name: Check TOML formatting
         run: taplo check '**/*.toml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,16 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - name: Install Just + Taplo
-        uses: extractions/setup-just@v4
-      - name: Install Taplo
-        run: just install-taplo
+      # taiki-e/install-action downloads a pre-built taplo binary directly
+      # from the upstream GitHub release (no cargo compile). ~1-3s installed
+      # vs ~2min for the previous `cargo install taplo-cli` path. The action
+      # also caches the binary across runs (key includes runner OS + version).
+      # Local dev: see `just install-taplo` — Justfile recipe uses the same
+      # upstream binary directly (curl + gunzip), so both CI and local paths
+      # get the same speedup.
+      - name: Install taplo
+        uses: taiki-e/install-action@v2
+        with:
+          tool: taplo-cli
       - name: Check TOML formatting
         run: taplo check '**/*.toml'

--- a/Justfile
+++ b/Justfile
@@ -104,15 +104,48 @@ alias c := check-deps
 @install-dev: check-deps
     uv pip install --editable ".[dev]"
 
-# Install Taplo in editable mode with dev dependencies
+# Install Taplo from upstream pre-built binary (much faster than `cargo install`,
+# which compiles from source — ~1s vs ~2min). Detects OS + arch and pulls the
+# matching release asset from https://github.com/tamasfe/taplo/releases.
+# Falls back to `cargo install` if the platform isn't covered.
+#
+# Uses a shebang body so bash interprets $(...) and ${...} directly — Just's
+# template engine would otherwise mangle them.
 [group('install')]
-@install-taplo:
-	if ! command -v taplo >/dev/null 2>&1; then \
-		cargo install taplo-cli && echo "{{GREEN}} Taplo installed successfully{{NC}}" || \
-		(echo "{{RED}}Failed to install taplo-cli.{{NC}} Try running '{{BLUE}}rustup update{{NC}}' to update your Rust toolchain." && exit 1); \
-	else \
-		echo "{{YELLOW}}Taplo is already installed{{NC}}"; \
-	fi
+install-taplo:
+    #!/usr/bin/env bash
+    set -eu
+    if command -v taplo >/dev/null 2>&1; then
+        echo -e "{{YELLOW}}Taplo is already installed{{NC}}"
+        exit 0
+    fi
+    VERSION=0.10.0
+    case "$(uname -s)" in
+        Linux*)  os=linux ;;
+        Darwin*) os=darwin ;;
+        *)       os= ;;
+    esac
+    case "$(uname -m)" in
+        x86_64)        arch=x86_64 ;;
+        arm64|aarch64) arch=aarch64 ;;
+        *)             arch= ;;
+    esac
+    if [ -z "$os" ] || [ -z "$arch" ]; then
+        echo -e "{{YELLOW}}No pre-built binary for $(uname -s)/$(uname -m); using cargo install{{NC}}"
+        cargo install taplo-cli \
+            || { echo -e "{{RED}}Failed to install taplo-cli.{{NC}} Try '{{BLUE}}rustup update{{NC}}' first." >&2; exit 1; }
+        exit 0
+    fi
+    INSTALL_DIR="${CARGO_HOME:-$HOME/.cargo}/bin"
+    mkdir -p "$INSTALL_DIR"
+    URL="https://github.com/tamasfe/taplo/releases/download/${VERSION}/taplo-${os}-${arch}.gz"
+    echo -e "{{BLUE}}Downloading $URL{{NC}}"
+    if curl -fsSL "$URL" | gunzip > "$INSTALL_DIR/taplo" && chmod +x "$INSTALL_DIR/taplo"; then
+        echo -e "{{GREEN}}✓ Taplo ${VERSION} installed to $INSTALL_DIR/taplo{{NC}}"
+    else
+        echo -e "{{RED}}Failed to download pre-built taplo; falling back to cargo install{{NC}}" >&2
+        cargo install taplo-cli
+    fi
 
 # Format code
 [group('dev')]

--- a/Justfile
+++ b/Justfile
@@ -139,10 +139,14 @@ install-taplo:
     INSTALL_DIR="${CARGO_HOME:-$HOME/.cargo}/bin"
     mkdir -p "$INSTALL_DIR"
     URL="https://github.com/tamasfe/taplo/releases/download/${VERSION}/taplo-${os}-${arch}.gz"
+    TMP_TAPLO="$(mktemp "$INSTALL_DIR/taplo.tmp.XXXXXX")"
+    trap 'rm -f "$TMP_TAPLO"' EXIT
     echo -e "{{BLUE}}Downloading $URL{{NC}}"
-    if curl -fsSL "$URL" | gunzip > "$INSTALL_DIR/taplo" && chmod +x "$INSTALL_DIR/taplo"; then
+    if curl -fsSL "$URL" | gunzip > "$TMP_TAPLO" && chmod +x "$TMP_TAPLO" && mv -f "$TMP_TAPLO" "$INSTALL_DIR/taplo"; then
+        trap - EXIT
         echo -e "{{GREEN}}✓ Taplo ${VERSION} installed to $INSTALL_DIR/taplo{{NC}}"
     else
+        rm -f "$TMP_TAPLO"
         echo -e "{{RED}}Failed to download pre-built taplo; falling back to cargo install{{NC}}" >&2
         cargo install taplo-cli
     fi

--- a/Justfile
+++ b/Justfile
@@ -114,7 +114,7 @@ alias c := check-deps
 [group('install')]
 install-taplo:
     #!/usr/bin/env bash
-    set -eu
+    set -euo pipefail
     if command -v taplo >/dev/null 2>&1; then
         echo -e "{{YELLOW}}Taplo is already installed{{NC}}"
         exit 0


### PR DESCRIPTION
## Summary

`toml-format-check` was the slowest job in CI at **~133 seconds**, almost entirely spent in `cargo install taplo-cli` (compiles Rust from source on every run). This PR swaps that for the upstream pre-built binary, via a single shared install path.

**Both CI and local dev call `just install-taplo`** — that recipe now downloads the upstream binary instead of compiling from source. Single source of truth, no third-party install action.

## What changed

- **Justfile `install-taplo`**: `cargo install taplo-cli` → `curl` from [tamasfe/taplo releases](https://github.com/tamasfe/taplo/releases) with OS/arch detection (Linux + Darwin × x86_64 + aarch64). Falls back to `cargo install` if the platform isn't covered. Recipe rewritten in shebang-body style for proper bash escaping.
- **`.github/workflows/ci.yml`**: kept the `extractions/setup-just@v4` step + `run: just install-taplo` — CI inherits the Justfile speedup automatically.

## Measured speedup

| Path | Before | After |
|---|---:|---:|
| Local (`just install-taplo` on Darwin arm64, fresh `CARGO_HOME`) | ~2-3 min | **2.3 s** |
| CI (`toml-format-check` job, full pipeline) | **133 s** | **9 s** |

~15× speedup on CI; ~50× speedup on local. The slowest CI check became the second-fastest.

## Why this approach over `taiki-e/install-action`

Initially tried `taiki-e/install-action@v2` for CI (it shaved ~5 more seconds via binary caching across runs — 4s vs 9s). Reverted to `just install-taplo` because:

- **Single source of truth**: Justfile is the install contract for both local + CI
- **No new third-party action dependency** in the supply chain
- **Decoupling cost is small**: the 5-second caching advantage isn't worth the maintenance + trust surface for a job that runs once per PR

Documented inline in the workflow's `Install taplo` step comment.

## Test plan

- [x] Justfile recipe verified locally on Darwin arm64: 2.3s wall time, binary works, reports `taplo 0.10.0`
- [x] CI `toml-format-check` measured at 9s (vs 133s) on this PR
- [x] YAML parses cleanly (4 jobs registered in ci.yml)
- [x] All other CI checks pass