### PR TITLE
ci: emit plain vX.Y.Z release tags (drop component prefix)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
     ".": {
       "release-type": "python",
       "package-name": "py_launch_blueprint",
+      "include-component-in-tag": false,
       "extra-files": [
         {
           "type": "toml",


### PR DESCRIPTION
## What

Sets `include-component-in-tag: false` in `release-please-config.json` so release-please tags future releases as `vX.Y.Z` instead of `py_launch_blueprint-vX.Y.Z`.

## Why

The component-prefixed tags (`py_launch_blueprint-v*`) never matched `publish.yml`'s trigger (`tags: ["v*"]`), so the release→publish chain never fired (publish.yml had **0** lifetime runs; package was 404 on PyPI). Plain `v*` tags align with the existing publish trigger.

## Companion manual changes (already applied, not in this diff)

- Renamed the 3 existing tags `py_launch_blueprint-v1.1.0/1/2` → `v1.1.0/1/2` (same commits).
- Repointed the 3 GitHub releases to the new tags.
- Publishing was suppressed during the retag (`gh workflow disable publish.yml`) → **0** PyPI uploads; workflow re-enabled afterward.

## Continuity

On merge, release-please will find the renamed `v1.1.2` release under the new pattern and compute the next version from there (no bootstrap-sha fallback). Verified post-merge.

## Note (separate issue, not addressed here)

Auto-publish still requires `RELEASE_PLEASE_APP_TOKEN`: a tag created by the default `GITHUB_TOKEN` does not trigger `publish.yml`.