### PR TITLE
ci: temporarily disable TestPyPI publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,33 +66,36 @@ jobs:
           if-no-files-found: error
 
   # ITM-050 - publish-testpypi: OIDC Trusted Publishing to TestPyPI.
-  publish-testpypi:
-    name: publish-testpypi
-    needs: build
-    runs-on: ubuntu-latest
-    environment: testpypi
-    permissions:
-      id-token: write  # Trusted Publishing only needs this
-    steps:
-      - name: Download dist/
-        uses: actions/download-artifact@v8
-        with:
-          name: dist
-          path: dist/
+  # TEMPORARILY DISABLED (for now): the whole publish-testpypi job is commented
+  # out so releases publish straight to PyPI, and publish-pypi depends directly
+  # on build (see below). To restore the TestPyPI smoke test, uncomment this job
+  # and change publish-pypi's `needs:` back to `publish-testpypi`.
+  # publish-testpypi:
+  #   name: publish-testpypi
+  #   needs: build
+  #   runs-on: ubuntu-latest
+  #   environment: testpypi
+  #   permissions:
+  #     id-token: write  # Trusted Publishing only needs this
+  #   steps:
+  #     - name: Download dist/
+  #       uses: actions/download-artifact@v8
+  #       with:
+  #         name: dist
+  #         path: dist/
+  #     - name: Install uv
+  #       uses: astral-sh/setup-uv@v7
+  #     - name: Publish to TestPyPI
+  #       run: |
+  #         uv publish --trusted-publishing always \
+  #           --publish-url https://test.pypi.org/legacy/ \
+  #           --check-url https://test.pypi.org/simple/
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Publish to TestPyPI
-        run: |
-          uv publish --trusted-publishing always \
-            --publish-url https://test.pypi.org/legacy/ \
-            --check-url https://test.pypi.org/simple/
-
-  # ITM-051 - publish-pypi: OIDC Trusted Publishing to PyPI (depends on TestPyPI).
+  # ITM-051 - publish-pypi: OIDC Trusted Publishing to PyPI.
+  # Depends directly on build while publish-testpypi is disabled (see above).
   publish-pypi:
     name: publish-pypi
-    needs: publish-testpypi
+    needs: build
     runs-on: ubuntu-latest
     environment: pypi
     permissions:


### PR DESCRIPTION
## What

Temporarily disables the `publish-testpypi` job in `publish.yml`. The job is **commented out** (not deleted), and `publish-pypi` is re-pointed from `needs: publish-testpypi` → `needs: build` so the production publish still runs.

Result: on a `v*` tag, the publish flow is now `build → publish-pypi` (straight to production PyPI), skipping the TestPyPI smoke test.

## Why this shape

- **Commented out, not `if: false`** — actionlint rejects constant `if:` conditions (`constant expression "false" in condition`), which would fail this repo's actionlint CI/pre-push gate.
- **`needs` rewire is required** — GitHub skips a job whose `needs:` target is skipped/absent, so leaving `publish-pypi` on `needs: publish-testpypi` would have silently skipped publishing entirely.

## Reversal (it's "for now")

Uncomment the `publish-testpypi` job block and change `publish-pypi`'s `needs:` back to `publish-testpypi`. The job's full definition is preserved in comments.

## Validation

- `actionlint .github/workflows/publish.yml` → clean
- Job graph: `build` → `publish-pypi` (`environment: pypi`, OIDC `id-token: write`)