### PR TITLE
chore: unify project version on pyproject as single source of truth

### DIFF
--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -3,7 +3,7 @@
   "Verbose": false,
   "Debug": false,
   "IgnoreDefaults": false,
-  "SpacesAftertabs": false,
+  "SpacesAfterTabs": false,
   "NoColor": false,
   "Exclude": [
     "\\.venv",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.1.2](https://github.com/smorinlabs/py-launch-blueprint/compare/py_launch_blueprint-v1.1.1...py_launch_blueprint-v1.1.2) (2026-05-26)
+## [1.1.2](https://github.com/smorinlabs/py-launch-blueprint/compare/v1.1.1...v1.1.2) (2026-05-26)
 
 
 ### Bug Fixes
@@ -8,7 +8,7 @@
 * **contributors:** filter bot identities from CONTRIBUTORS.md ([d895eb6](https://github.com/smorinlabs/py-launch-blueprint/commit/d895eb69efb4964ff3bf23d50b17b5013e71c026))
 * **contributors:** filter bot identities from CONTRIBUTORS.md ([#332](https://github.com/smorinlabs/py-launch-blueprint/issues/332)) ([c31c4b0](https://github.com/smorinlabs/py-launch-blueprint/commit/c31c4b0fba0bc5d317d81ad673adab52b0266c9f))
 
-## [1.1.1](https://github.com/smorinlabs/py-launch-blueprint/compare/py_launch_blueprint-v1.1.0...py_launch_blueprint-v1.1.1) (2026-05-26)
+## [1.1.1](https://github.com/smorinlabs/py-launch-blueprint/compare/v1.1.0...v1.1.1) (2026-05-26)
 
 
 ### Performance Improvements
@@ -16,7 +16,7 @@
 * **ci:** swap taplo install from cargo build to pre-built binary (~40x faster) ([1f58d5a](https://github.com/smorinlabs/py-launch-blueprint/commit/1f58d5a4945df647da032e538c0f3bdf5986dcc7))
 * **ci:** swap taplo install from cargo build to pre-built binary (~40x faster) ([#327](https://github.com/smorinlabs/py-launch-blueprint/issues/327)) ([06c0590](https://github.com/smorinlabs/py-launch-blueprint/commit/06c0590e8076139c8b4311d834e801f8b7633882))
 
-## [1.1.0](https://github.com/smorinlabs/py-launch-blueprint/compare/py_launch_blueprint-v1.0.0...py_launch_blueprint-v1.1.0) (2026-05-26)
+## [1.1.0](https://github.com/smorinlabs/py-launch-blueprint/compare/v1.0.0...v1.1.0) (2026-05-26)
 
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ Teams and professionals needing maintainable, type-safe Python projects followin
 
 - **Issue templates (Feature, Bug, Documentation)**: Standardize issue reporting with appropriate fields for each type, gathering all necessary information upfront.
 
-- **Automated contributor recognition with `cog`**: Automatically update contributor lists with cog, acknowledging all project participants without manual tracking.
+- **Automated contributor recognition with `contributors-please`**: Automatically update contributor lists, acknowledging all project participants without manual tracking.
 
-- **Conventional commits support with `cog`**: Enforce structured commit messages, enabling automated changelog generation and version management.
+- **Conventional commits enforced with `commitlint`**: Enforce structured commit messages so `release-please` can automate changelog generation and version bumps.
 
 - **Security policy**: Establish clear vulnerability reporting procedures, promoting responsible disclosure and faster security fixes.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,10 +6,15 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
+from py_launch_blueprint import __version__
+
 project = 'py-launch-blueprint'
 copyright = '2025, Steve Morin'
 author = 'Steve Morin'
-release = '0.1.0'
+# Single-sourced from pyproject.toml [project] version via the installed
+# package metadata (py_launch_blueprint.__version__); never hardcode here.
+release = __version__
+version = '.'.join(release.split('.')[:2])
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/init/manifest.toml
+++ b/init/manifest.toml
@@ -39,6 +39,7 @@ files   = [
   "tests/test_api.py",   # 1x
   "tests/test_cli.py",   # 1x
   "tests/test_config.py",   # 1x
+  "tests/test_version_consistency.py",   # 1x
 ]
 mode    = "text"
 
@@ -150,6 +151,7 @@ files   = [
   "tests/test_api.py",   # 1x
   "tests/test_cli.py",   # 10x
   "tests/test_config.py",   # 1x
+  "tests/test_version_consistency.py",   # 2x
 ]
 mode    = "text"
 

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2025, Steve Morin
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""Guard that the project version stays single-sourced.
+
+``pyproject.toml`` ``[project] version`` is the single source of truth (ADR-06).
+release-please bumps it together with ``.release-please-manifest.json``, and the
+CLI/docs derive their version from the installed package metadata
+(``py_launch_blueprint.__version__``). These tests fail if any of those copies
+drift apart.
+"""
+
+import json
+import tomllib
+from pathlib import Path
+
+from py_launch_blueprint import __version__
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _pyproject_version() -> str:
+    data = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    return data["project"]["version"]
+
+
+def _manifest_version() -> str:
+    data = json.loads((ROOT / ".release-please-manifest.json").read_text())
+    return data["."]
+
+
+def test_manifest_matches_pyproject():
+    """release-please bumps both; they must never diverge."""
+    assert _manifest_version() == _pyproject_version()
+
+
+def test_installed_version_matches_pyproject():
+    """The CLI/docs derive __version__ from installed metadata.
+
+    Requires a synced environment (``uv sync``); the version baked into the
+    installed distribution must match the source-of-truth in pyproject.toml.
+    """
+    assert __version__ == _pyproject_version()


### PR DESCRIPTION
## Goal

Make `pyproject.toml [project] version` the single source of truth for the project version (ADR-06). Every other consumer either **derives** it or is **guarded** against drift. No second hand-edited version literal anywhere.

## Changes

| File | Change | Type |
|---|---|---|
| `docs/source/conf.py` | `release` was hardcoded `0.1.0` (stale) → now `from py_launch_blueprint import __version__` (+ short `version`). Resolves to `1.1.2`/`1.1`. | docs |
| `tests/test_version_consistency.py` | **New guard**: asserts `pyproject == manifest` and installed `__version__ == pyproject`. | test |
| `README.md` | Drop 2 stale `cog` references → `contributors-please` and `commitlint`/`release-please`. | docs |
| `CHANGELOG.md` | Repair 3 compare URLs (`py_launch_blueprint-v*` → `v*`) broken by the tag rename in #335. | docs |

## Version flow after this PR

```
pyproject.toml [project] version   ◄── the ONE editable literal (release-please bumps it)
  ├─ installed dist metadata → __version__ → CLI --version  AND  docs/conf.py
  ├─ .release-please-manifest.json   ◄── auto-bumped + GUARDED by the new test
  └─ git tag → publish.yml verifies tag == pyproject
```

## Verification

- `just test` → **27 passed** (incl. 2 new guards)
- Guard proven to catch drift: setting manifest to a wrong value fails `test_manifest_matches_pyproject` (`assert '9.9.9' == '1.1.2'`); restoring it passes.
- `just lint`, `just typecheck`, `just format`, `make check` → all clean
- `conf.py` executed → `release=1.1.2`, `version=1.1`

## Non-releasing

All commits use hidden conventional types (`test`/`docs`) — this is internal/docs/test plumbing and doesn't change the shipped package, so it intentionally won't trigger a release.