### PR TITLE
ci: mint github app token in release-please for downstream triggers

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,6 +1,15 @@
 # Release-please workflow (ITM-052 + ITM-053 + ITM-054).
 # Opens release PR on push to main; sync-uv-lock keeps uv.lock current.
-# Per ADR-05; default GitHub App token, GITHUB_TOKEN fallback documented.
+# Per ADR-05. Auth uses one of two mechanisms that can BOTH open PRs and trigger
+# downstream workflows (publish.yml) — GITHUB_TOKEN is intentionally NOT used as
+# a fallback, since it never triggers downstream workflows and may be blocked
+# from opening PRs by org policy:
+#   1. GitHub App (preferred): set RELEASE_PLEASE_APP_ID + RELEASE_PLEASE_PRIVATE_KEY
+#      (App with Contents + Pull requests: write); both jobs mint an installation
+#      token from them.
+#   2. Fallback PAT: set RELEASE_PLEASE_APP_TOKEN (fine-grained PAT, Contents +
+#      Pull requests: write).
+# See RELEASE.md for setup. With neither configured, release-please fails fast.
 
 name: release-please
 
@@ -21,18 +30,31 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    env:
+      # Surfaced so the app-token step's `if:` can test it (secrets are not
+      # available directly in `if:` conditions). Empty unless the App is set up.
+      RP_APP_ID: ${{ secrets.RELEASE_PLEASE_APP_ID }}
     outputs:
       release_created: ${{ steps.rp.outputs.release_created }}
       pr: ${{ steps.rp.outputs.pr }}
     steps:
+      # Mint a GitHub App installation token when the App is configured, so the
+      # release PR/tag triggers downstream workflows. Skipped otherwise.
+      - name: Mint release-please app token
+        id: app-token
+        if: ${{ env.RP_APP_ID != '' }}
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
+
       - name: release-please
         id: rp
         uses: googleapis/release-please-action@v5.0.0
         with:
-          # Prefer App token for downstream-workflow triggering; fall back to
-          # GITHUB_TOKEN if RELEASE_PLEASE_APP_TOKEN secret is not configured.
-          # See CONTRIBUTING.md for App setup.
-          token: ${{ secrets.RELEASE_PLEASE_APP_TOKEN || secrets.GITHUB_TOKEN }}
+          # Minted App installation token (preferred) or the RELEASE_PLEASE_APP_TOKEN
+          # PAT — both open PRs and trigger downstream workflows. See RELEASE.md.
+          token: ${{ steps.app-token.outputs.token || secrets.RELEASE_PLEASE_APP_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
@@ -46,12 +68,25 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    env:
+      RP_APP_ID: ${{ secrets.RELEASE_PLEASE_APP_ID }}
     steps:
+      # Mint a fresh installation token from the same App (a separate token —
+      # steps don't cross jobs) so the uv.lock sync commit pushed to the release
+      # PR branch also triggers its CI checks.
+      - name: Mint release-please app token
+        id: app-token
+        if: ${{ env.RP_APP_ID != '' }}
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
+
       - name: Checkout release PR branch
         uses: actions/checkout@v6
         with:
           ref: ${{ fromJson(needs.release-please.outputs.pr).headBranchName }}
-          token: ${{ secrets.RELEASE_PLEASE_APP_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token || secrets.RELEASE_PLEASE_APP_TOKEN }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,13 +32,25 @@ The `publish` workflow still fires on the tag and uploads to PyPI.
 
 ## Token setup
 
-Default token for the release-please job is `RELEASE_PLEASE_APP_TOKEN`
-(GitHub App, needed so the merge of release-please's PR re-triggers
-downstream workflows). Falls back to `GITHUB_TOKEN` if the secret is
-not set — fine for single-repo use but won't re-trigger other workflows.
+release-please must authenticate with a token that can **both** open PRs and
+trigger downstream workflows (so merging the release PR fires `publish.yml`).
+`GITHUB_TOKEN` does neither reliably — it never re-triggers other workflows, and
+org policy can block it from opening PRs — so it is **not** used. Configure one
+of these two mechanisms instead:
 
-App setup: https://github.com/apps/release-please-action — install on
-the repo and create a secret named `RELEASE_PLEASE_APP_TOKEN`.
+1. **GitHub App (preferred).** Create a GitHub App with **Contents** and
+   **Pull requests: write**, install it on this repo, then add two secrets:
+   - `RELEASE_PLEASE_APP_ID` — the App's numeric ID
+   - `RELEASE_PLEASE_PRIVATE_KEY` — the App's private key (`.pem` contents)
+
+   Both jobs mint a short-lived installation token from these.
+
+2. **Fallback PAT.** Create a fine-grained Personal Access Token scoped to this
+   repo with **Contents** and **Pull requests: write**, stored as the
+   `RELEASE_PLEASE_APP_TOKEN` secret.
+
+With neither configured, release-please fails fast rather than silently
+producing a release that can't publish.
 
 ## First-release cutover (one-time)
 


### PR DESCRIPTION
## What

`release-please.yml` now mints a **GitHub App installation token** (via `actions/create-github-app-token@v2`) in both jobs when the App secrets are configured, and passes it to release-please / the uv.lock checkout.

## Why

A tag/PR created with the default `GITHUB_TOKEN` does **not** trigger other workflows — which is why `publish.yml` has never fired. An App installation token does trigger them, closing the last gap in the release→publish chain.

## Graceful fallback (blueprint-safe)

Gated on `RELEASE_PLEASE_APP_ID`:
- **Secrets set** → mint App token → `token: ${{ steps.app-token.outputs.token }}` (triggers downstream).
- **Secrets absent** → mint step skipped → `token: ${{ ... || secrets.GITHUB_TOKEN }}` (works, no downstream trigger).

So merging is safe before the secrets exist, and template/generated projects without an App still get a working release-please. (`secrets` can't be read in `if:`, so the App ID is surfaced via the `RP_APP_ID` env var to gate the step.)

## Requires (manual, repo owner)

Create a GitHub App (Contents + Pull requests: write), install it on this repo, then set:
- `RELEASE_PLEASE_APP_ID`
- `RELEASE_PLEASE_PRIVATE_KEY`

## Validation

- `actionlint` → clean
- blueprint manifest-drift guard → not flagged (no new identity values)