### PR TITLE
ci: enable dispatch-only Flox-vs-traditional CI timing experiment

### DIFF
--- a/.github/actions/provision-flox/action.yml
+++ b/.github/actions/provision-flox/action.yml
@@ -1,0 +1,26 @@
+name: provision-flox
+description: Install Flox and restore/save the Nix store cache.
+inputs:
+  cache:
+    description: cold | warm
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Install Flox
+      uses: flox/install-flox-action@v2
+    - name: Cache Nix store
+      uses: actions/cache@v4
+      with:
+        path: |
+          /nix
+          ~/.cache/flox
+        # cold -> unique key (guaranteed miss); warm -> stable key per lock+os
+        key: >-
+          flox-${{ inputs.cache }}-${{ runner.os }}-${{ hashFiles('.flox/env/manifest.lock') }}-${{
+            inputs.cache == 'cold' && github.run_id || 'stable' }}
+        restore-keys: |
+          ${{ inputs.cache == 'warm' && format('flox-warm-{0}-{1}-stable', runner.os, hashFiles('.flox/env/manifest.lock')) || 'flox-never-restore' }}
+    - name: Warm the flox env
+      shell: bash
+      run: flox activate -- true

--- a/.github/actions/provision-traditional/action.yml
+++ b/.github/actions/provision-traditional/action.yml
@@ -1,0 +1,35 @@
+name: provision-traditional
+description: Install the traditional per-tool toolchain (uv / just / bun / gitleaks).
+inputs:
+  tools:
+    description: space-separated subset of "uv just bun gitleaks"
+    required: true
+  cache:
+    description: cold | warm
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Setup uv
+      if: contains(inputs.tools, 'uv')
+      uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: ${{ inputs.cache == 'warm' }}
+    - name: Setup just
+      if: contains(inputs.tools, 'just')
+      uses: extractions/setup-just@v4
+    - name: Install taplo (when just present)
+      if: contains(inputs.tools, 'just')
+      shell: bash
+      run: just install-taplo
+    - name: Setup bun
+      if: contains(inputs.tools, 'bun')
+      uses: oven-sh/setup-bun@v2
+    - name: Install gitleaks
+      if: contains(inputs.tools, 'gitleaks')
+      shell: bash
+      run: bash scripts/install-gitleaks.sh
+    - name: Ensure gitleaks on PATH
+      if: contains(inputs.tools, 'gitleaks')
+      shell: bash
+      run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -1,0 +1,245 @@
+name: _checks
+on:
+  workflow_call:
+    inputs:
+      provisioner:
+        type: string
+        required: true   # traditional | flox
+      os:
+        type: string
+        required: true
+      cache:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  ruff-check:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: provision (traditional)
+        if: inputs.provisioner == 'traditional'
+        uses: ./.github/actions/provision-traditional
+        with:
+          tools: uv
+          cache: ${{ inputs.cache }}
+      - name: provision (flox)
+        if: inputs.provisioner == 'flox'
+        uses: ./.github/actions/provision-flox
+        with:
+          cache: ${{ inputs.cache }}
+      - name: run
+        shell: bash
+        run: ${{ inputs.provisioner == 'flox' && 'flox activate -- ruff check .' || 'uvx ruff check .' }}
+
+  ruff-format:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: provision (traditional)
+        if: inputs.provisioner == 'traditional'
+        uses: ./.github/actions/provision-traditional
+        with:
+          tools: uv
+          cache: ${{ inputs.cache }}
+      - name: provision (flox)
+        if: inputs.provisioner == 'flox'
+        uses: ./.github/actions/provision-flox
+        with:
+          cache: ${{ inputs.cache }}
+      - name: run
+        shell: bash
+        run: ${{ inputs.provisioner == 'flox' && 'flox activate -- ruff format --check .' || 'uvx ruff format --check .' }}
+
+  ty:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: provision (traditional)
+        if: inputs.provisioner == 'traditional'
+        uses: ./.github/actions/provision-traditional
+        with:
+          tools: uv
+          cache: ${{ inputs.cache }}
+      - name: provision (flox)
+        if: inputs.provisioner == 'flox'
+        uses: ./.github/actions/provision-flox
+        with:
+          cache: ${{ inputs.cache }}
+      - name: run
+        shell: bash
+        run: |
+          if [ "${{ inputs.provisioner }}" = "flox" ]; then
+            flox activate -- bash -c 'uv sync --group dev && uv run ty check py_launch_blueprint/'
+          else
+            uv sync --group dev && uv run ty check py_launch_blueprint/
+          fi
+
+  pytest:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: provision (traditional)
+        if: inputs.provisioner == 'traditional'
+        uses: ./.github/actions/provision-traditional
+        with:
+          tools: uv
+          cache: ${{ inputs.cache }}
+      - name: provision (flox)
+        if: inputs.provisioner == 'flox'
+        uses: ./.github/actions/provision-flox
+        with:
+          cache: ${{ inputs.cache }}
+      - name: run
+        shell: bash
+        run: |
+          if [ "${{ inputs.provisioner }}" = "flox" ]; then
+            flox activate -- bash -c 'uv sync --group dev && uv run pytest -m "" --cov=py_launch_blueprint --cov-report=xml'
+          else
+            uv sync --group dev && uv run pytest -m "" --cov=py_launch_blueprint --cov-report=xml
+          fi
+
+  taplo:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: provision (traditional)
+        if: inputs.provisioner == 'traditional'
+        uses: ./.github/actions/provision-traditional
+        with:
+          tools: just
+          cache: ${{ inputs.cache }}
+      - name: provision (flox)
+        if: inputs.provisioner == 'flox'
+        uses: ./.github/actions/provision-flox
+        with:
+          cache: ${{ inputs.cache }}
+      - name: run
+        shell: bash
+        run: |
+          if [ "${{ inputs.provisioner }}" = "flox" ]; then
+            flox activate -- taplo check '**/*.toml'
+          else
+            taplo check '**/*.toml'
+          fi
+
+  codespell:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: provision (traditional)
+        if: inputs.provisioner == 'traditional'
+        uses: ./.github/actions/provision-traditional
+        with:
+          tools: uv
+          cache: ${{ inputs.cache }}
+      - name: provision (flox)
+        if: inputs.provisioner == 'flox'
+        uses: ./.github/actions/provision-flox
+        with:
+          cache: ${{ inputs.cache }}
+      - name: run
+        shell: bash
+        run: ${{ inputs.provisioner == 'flox' && 'flox activate -- codespell --toml pyproject.toml' || 'uvx codespell --toml pyproject.toml' }}
+
+  yamllint:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: provision (traditional)
+        if: inputs.provisioner == 'traditional'
+        uses: ./.github/actions/provision-traditional
+        with:
+          tools: uv
+          cache: ${{ inputs.cache }}
+      - name: provision (flox)
+        if: inputs.provisioner == 'flox'
+        uses: ./.github/actions/provision-flox
+        with:
+          cache: ${{ inputs.cache }}
+      - name: run
+        shell: bash
+        run: ${{ inputs.provisioner == 'flox' && 'flox activate -- yamllint -c .yamllint .' || 'uvx yamllint -c .yamllint .' }}
+
+  editorconfig:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: provision (traditional)
+        if: inputs.provisioner == 'traditional'
+        uses: ./.github/actions/provision-traditional
+        with:
+          tools: bun
+          cache: ${{ inputs.cache }}
+      - name: provision (flox)
+        if: inputs.provisioner == 'flox'
+        uses: ./.github/actions/provision-flox
+        with:
+          cache: ${{ inputs.cache }}
+      - name: run
+        shell: bash
+        run: ${{ inputs.provisioner == 'flox' && 'flox activate -- editorconfig-checker --config .editorconfig-checker.json' || 'bunx --bun editorconfig-checker --config .editorconfig-checker.json' }}
+
+  bandit:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: provision (traditional)
+        if: inputs.provisioner == 'traditional'
+        uses: ./.github/actions/provision-traditional
+        with:
+          tools: uv
+          cache: ${{ inputs.cache }}
+      - name: provision (flox)
+        if: inputs.provisioner == 'flox'
+        uses: ./.github/actions/provision-flox
+        with:
+          cache: ${{ inputs.cache }}
+      - name: run
+        shell: bash
+        run: ${{ inputs.provisioner == 'flox' && 'flox activate -- bandit -r py_launch_blueprint/ -c pyproject.toml' || 'uvx bandit -r py_launch_blueprint/ -c pyproject.toml' }}
+
+  gitleaks:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: provision (traditional)
+        if: inputs.provisioner == 'traditional'
+        uses: ./.github/actions/provision-traditional
+        with:
+          tools: gitleaks
+          cache: ${{ inputs.cache }}
+      - name: provision (flox)
+        if: inputs.provisioner == 'flox'
+        uses: ./.github/actions/provision-flox
+        with:
+          cache: ${{ inputs.cache }}
+      - name: run
+        shell: bash
+        run: ${{ inputs.provisioner == 'flox' && 'flox activate -- gitleaks detect --source . --no-banner' || 'gitleaks detect --source . --no-banner' }}
+
+  commitlint:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: provision (traditional)
+        if: inputs.provisioner == 'traditional'
+        uses: ./.github/actions/provision-traditional
+        with:
+          tools: bun
+          cache: ${{ inputs.cache }}
+      - name: provision (flox)
+        if: inputs.provisioner == 'flox'
+        uses: ./.github/actions/provision-flox
+        with:
+          cache: ${{ inputs.cache }}
+      - name: run
+        shell: bash
+        run: ${{ inputs.provisioner == 'flox' && 'flox activate -- commitlint --from=HEAD~10 --to=HEAD' || 'bunx --bun commitlint --from=HEAD~10 --to=HEAD' }}

--- a/.github/workflows/experiment-driver.yml
+++ b/.github/workflows/experiment-driver.yml
@@ -43,6 +43,32 @@ jobs:
           IFS=',' read -ra SIDE_ARR <<< "$SIDES"
           IFS=',' read -ra OS_ARR <<< "$OSES"
           IFS=',' read -ra CACHE_ARR <<< "$CACHES"
+
+          # Dispatch a workflow and return the run id it actually created.
+          # Snapshots existing workflow_dispatch run ids before dispatching,
+          # then polls for the new id that wasn't present before. This avoids
+          # the `gh run list --limit 1` race, which could return a different
+          # run (concurrent/manual dispatch) and silently misattribute timings.
+          dispatch_run() {
+            local wfname="$1" os="$2" cache="$3" before id
+            before=$(gh run list --workflow="${wfname}.yml" --branch "$REF" \
+              --event workflow_dispatch --limit 60 --json databaseId \
+              -q '[.[].databaseId] | join(" ")')
+            gh workflow run "${wfname}.yml" --ref "$REF" -f os="$os" -f cache="$cache"
+            for _ in $(seq 1 30); do
+              sleep 6
+              for id in $(gh run list --workflow="${wfname}.yml" --branch "$REF" \
+                --event workflow_dispatch --limit 60 --json databaseId \
+                -q '.[].databaseId'); do
+                case " ${before} " in
+                  *" ${id} "*) ;;
+                  *) echo "${id}"; return 0 ;;
+                esac
+              done
+            done
+            return 1
+          }
+
           collect='{}'
           for side in "${SIDE_ARR[@]}"; do
             case "$side" in
@@ -55,29 +81,37 @@ jobs:
               for cache in "${CACHE_ARR[@]}"; do
                 # warm: prime once (not measured) so the measured runs hit cache
                 if [ "$cache" = "warm" ]; then
-                  gh workflow run "${wf}.yml" --ref "$REF" -f os="$os" -f cache="warm" || true
-                  sleep 45
-                  prime_id=$(gh run list --workflow="${wf}.yml" \
-                    --branch "$REF" --limit 1 \
-                    --json databaseId -q '.[0].databaseId')
-                  gh run watch "$prime_id" --exit-status || true
+                  if prime_id=$(dispatch_run "$wf" "$os" "warm"); then
+                    gh run watch "$prime_id" --exit-status || true
+                  else
+                    echo "WARN: could not identify warm-prime run for $wf/$os" >&2
+                  fi
                 fi
                 ids=()
                 for rep in $(seq 1 "$REPS"); do
                   echo "rep $rep of $REPS: side=$side os=$os cache=$cache"
-                  gh workflow run "${wf}.yml" --ref "$REF" -f os="$os" -f cache="$cache"
-                  sleep 45
-                  rid=$(gh run list --workflow="${wf}.yml" \
-                    --branch "$REF" --limit 1 \
-                    --json databaseId -q '.[0].databaseId')
-                  gh run watch "$rid" --exit-status || true
-                  ids+=("$rid")
+                  if ! rid=$(dispatch_run "$wf" "$os" "$cache"); then
+                    echo "WARN: could not identify dispatched run; skipping rep" >&2
+                    continue
+                  fi
+                  # Only record successful runs — a failed/wrong run must not be
+                  # counted as a valid timing sample (would bias the experiment).
+                  if gh run watch "$rid" --exit-status; then
+                    ids+=("$rid")
+                  else
+                    echo "WARN: run $rid concluded non-success; excluding from samples" >&2
+                  fi
                 done
                 tag="${side}|${os}|${cache}"
-                joined=$(printf '%s\n' "${ids[@]}" | paste -sd, -)
-                collect=$(echo "$collect" | \
-                  jq --arg k "$tag" --arg v "$joined" \
-                  '.[$k] = ($v|split(",")|map(tonumber))')
+                if [ "${#ids[@]}" -gt 0 ]; then
+                  joined=$(printf '%s\n' "${ids[@]}" | paste -sd, -)
+                  collect=$(echo "$collect" | \
+                    jq --arg k "$tag" --arg v "$joined" \
+                    '.[$k] = ($v|split(",")|map(tonumber))')
+                else
+                  echo "WARN: no successful reps recorded for $tag" >&2
+                  collect=$(echo "$collect" | jq --arg k "$tag" '.[$k] = []')
+                fi
               done
             done
           done

--- a/.github/workflows/experiment-driver.yml
+++ b/.github/workflows/experiment-driver.yml
@@ -1,0 +1,89 @@
+name: experiment-driver
+on:
+  workflow_dispatch:
+    inputs:
+      sides:
+        description: comma-separated subset of traditional,flox-mirror,flox-consolidated
+        type: string
+        default: traditional,flox-mirror,flox-consolidated
+      oses:
+        description: comma-separated subset of ubuntu-latest,macos-latest
+        type: string
+        default: ubuntu-latest
+      caches:
+        description: comma-separated subset of cold,warm
+        type: string
+        default: cold,warm
+      reps:
+        description: repetitions per cell
+        type: string
+        default: "5"
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  drive:
+    runs-on: ubuntu-latest
+    timeout-minutes: 350
+    steps:
+      - uses: actions/checkout@v6
+      - name: Dispatch, wait, collect run IDs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF: ${{ github.ref_name }}
+          SIDES: ${{ inputs.sides }}
+          OSES: ${{ inputs.oses }}
+          CACHES: ${{ inputs.caches }}
+          REPS: ${{ inputs.reps }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          IFS=',' read -ra SIDE_ARR <<< "$SIDES"
+          IFS=',' read -ra OS_ARR <<< "$OSES"
+          IFS=',' read -ra CACHE_ARR <<< "$CACHES"
+          collect='{}'
+          for side in "${SIDE_ARR[@]}"; do
+            case "$side" in
+              traditional) wf="trad-suite" ;;
+              flox-mirror) wf="flox-mirror-suite" ;;
+              flox-consolidated) wf="flox-consolidated" ;;
+              *) echo "unknown side: $side" >&2; exit 1 ;;
+            esac
+            for os in "${OS_ARR[@]}"; do
+              for cache in "${CACHE_ARR[@]}"; do
+                # warm: prime once (not measured) so the measured runs hit cache
+                if [ "$cache" = "warm" ]; then
+                  gh workflow run "${wf}.yml" --ref "$REF" -f os="$os" -f cache="warm" || true
+                  sleep 45
+                  prime_id=$(gh run list --workflow="${wf}.yml" \
+                    --branch "$REF" --limit 1 \
+                    --json databaseId -q '.[0].databaseId')
+                  gh run watch "$prime_id" --exit-status || true
+                fi
+                ids=()
+                for rep in $(seq 1 "$REPS"); do
+                  echo "rep $rep of $REPS: side=$side os=$os cache=$cache"
+                  gh workflow run "${wf}.yml" --ref "$REF" -f os="$os" -f cache="$cache"
+                  sleep 45
+                  rid=$(gh run list --workflow="${wf}.yml" \
+                    --branch "$REF" --limit 1 \
+                    --json databaseId -q '.[0].databaseId')
+                  gh run watch "$rid" --exit-status || true
+                  ids+=("$rid")
+                done
+                tag="${side}|${os}|${cache}"
+                joined=$(printf '%s\n' "${ids[@]}" | paste -sd, -)
+                collect=$(echo "$collect" | \
+                  jq --arg k "$tag" --arg v "$joined" \
+                  '.[$k] = ($v|split(",")|map(tonumber))')
+              done
+            done
+          done
+          echo "$collect" > run-ids.json
+          cat run-ids.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: experiment-run-ids
+          path: run-ids.json

--- a/.github/workflows/flox-consolidated.yml
+++ b/.github/workflows/flox-consolidated.yml
@@ -1,0 +1,52 @@
+name: flox-consolidated
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        type: string
+        required: true
+      cache:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  hygiene:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: provision (flox)
+        uses: ./.github/actions/provision-flox
+        with:
+          cache: ${{ inputs.cache }}
+      - name: all hygiene checks under one activation
+        shell: bash
+        run: |
+          flox activate -- bash -euo pipefail -c '
+            ruff check .
+            ruff format --check .
+            uv sync --group dev && uv run ty check py_launch_blueprint/
+            taplo check "**/*.toml"
+            codespell --toml pyproject.toml
+            yamllint -c .yamllint .
+            editorconfig-checker --config .editorconfig-checker.json
+            bandit -r py_launch_blueprint/ -c pyproject.toml
+            gitleaks detect --source . --no-banner
+            commitlint --from=HEAD~10 --to=HEAD
+          '
+
+  pytest:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: provision (flox)
+        uses: ./.github/actions/provision-flox
+        with:
+          cache: ${{ inputs.cache }}
+      - name: tests under one activation
+        shell: bash
+        run: flox activate -- bash -c 'uv sync --group dev && uv run pytest -m "" --cov=py_launch_blueprint --cov-report=xml'

--- a/.github/workflows/flox-mirror-suite.yml
+++ b/.github/workflows/flox-mirror-suite.yml
@@ -1,0 +1,21 @@
+name: flox-mirror-suite
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        type: string
+        required: true
+      cache:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    uses: ./.github/workflows/_checks.yml
+    with:
+      provisioner: flox
+      os: ${{ inputs.os }}
+      cache: ${{ inputs.cache }}

--- a/.github/workflows/trad-suite.yml
+++ b/.github/workflows/trad-suite.yml
@@ -1,0 +1,21 @@
+name: trad-suite
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        type: string
+        required: true
+      cache:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    uses: ./.github/workflows/_checks.yml
+    with:
+      provisioner: traditional
+      os: ${{ inputs.os }}
+      cache: ${{ inputs.cache }}

--- a/init/manifest.toml
+++ b/init/manifest.toml
@@ -118,13 +118,15 @@ files   = [
 ]
 mode    = "structured"
 
-# package_name (text) — 73 occurrences in 28 files
+# package_name (text) — 82 occurrences in 30 files
 [[replace]]
 field   = "package_name"
 current = ["py_launch_blueprint"]
 files   = [
+  ".github/workflows/_checks.yml",   # 6x
   ".github/workflows/bandit.yml",   # 1x
   ".github/workflows/ci.yml",   # 2x
+  ".github/workflows/flox-consolidated.yml",   # 3x
   ".vscode/launch.json",   # 2x
   ".windsurfrules",   # 1x
   "AGENTS.md",   # 1x


### PR DESCRIPTION
## What
Adds the **dispatch-only** workflows + composite actions for the Flox-vs-traditional CI timing experiment to `main`.

GitHub only allows `workflow_dispatch` workflows to be triggered if they exist on the default branch. This PR unlocks dispatch; the full harness (analysis code, flox env, fixtures, docs) lives on branch `experiment/flox-ci-timing` and is what actually runs when dispatched with `--ref experiment/flox-ci-timing`.

## Footprint on main
These are **`workflow_dispatch`-only** — they never run on push or PR. They only execute when explicitly triggered. No change to normal CI.

## Files
- `.github/workflows/_checks.yml` — reusable, 11 checks parameterized by provisioner
- `.github/workflows/{trad-suite,flox-mirror-suite,flox-consolidated}.yml` — the three measured sides
- `.github/workflows/experiment-driver.yml` — serial run orchestrator
- `.github/actions/provision-{flox,traditional}/` — provisioning composites

## After merge
```
gh workflow run trad-suite.yml --ref experiment/flox-ci-timing -f os=ubuntu-latest -f cache=cold
```
runs the branch's version (Gate 2 correctness, then Gate 3 timing via the driver).

Design + ADR-12 live on the `experiment/flox-ci-timing` branch under `docs/`.
