### PR TITLE
ci: enable dispatch-only mise CI timing experiment workflows

### DIFF
--- a/.github/actions/provision-mise/action.yml
+++ b/.github/actions/provision-mise/action.yml
@@ -1,0 +1,23 @@
+name: provision-mise
+description: Install mise and the toolchain declared in mise.toml, with cache.
+inputs:
+  cache:
+    description: cold | warm
+    required: true
+runs:
+  using: composite
+  steps:
+    # Point mise at the experiment config (kept out of the repo root so a local
+    # mise install doesn't auto-load it and shadow the flox/uv setup). Set in
+    # GITHUB_ENV so the mise-action AND the later `mise exec` run steps use it.
+    - name: Point mise at experiment/mise.toml
+      shell: bash
+      run: echo "MISE_CONFIG_FILE=${GITHUB_WORKSPACE}/experiment/mise.toml" >> "$GITHUB_ENV"
+    # jdx/mise-action installs mise, runs `mise install` (reads MISE_CONFIG_FILE),
+    # and puts the tools on PATH. cache=true (warm) restores/saves mise's install
+    # dir; cache=false (cold) installs fresh every run.
+    - name: Install mise + tools
+      uses: jdx/mise-action@v2
+      with:
+        cache: ${{ inputs.cache == 'warm' }}
+        install: true

--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       provisioner:
         type: string
-        required: true   # traditional | flox
+        required: true   # traditional | flox | mise
       os:
         type: string
         required: true
@@ -14,6 +14,15 @@ on:
 
 permissions:
   contents: read
+
+# NOTE: the `editorconfig` check was removed from this experiment. Its only
+# traditional path (npm editorconfig-checker) downloads a binary from GitHub at
+# runtime, which flaked (~45%: rate-limit + TAR_BAD_ARCHIVE) under the driver's
+# rapid dispatches — isolated to that one job. Excluded from all sides for fairness.
+#
+# Each job: checkout -> one provision step (gated by `provisioner`) -> run the
+# check. flox runs the bare tool under `flox activate --`; mise under `mise exec
+# --`; traditional uses uvx/bunx/uv-run as the repo does today.
 
 jobs:
   ruff-check:
@@ -31,9 +40,19 @@ jobs:
         uses: ./.github/actions/provision-flox
         with:
           cache: ${{ inputs.cache }}
+      - name: provision (mise)
+        if: inputs.provisioner == 'mise'
+        uses: ./.github/actions/provision-mise
+        with:
+          cache: ${{ inputs.cache }}
       - name: run
         shell: bash
-        run: ${{ inputs.provisioner == 'flox' && 'flox activate -- ruff check .' || 'uvx ruff check .' }}
+        run: |
+          case "${{ inputs.provisioner }}" in
+            flox) flox activate -- ruff check . ;;
+            mise) mise exec -- ruff check . ;;
+            *)    uvx ruff check . ;;
+          esac
 
   ruff-format:
     runs-on: ${{ inputs.os }}
@@ -50,9 +69,19 @@ jobs:
         uses: ./.github/actions/provision-flox
         with:
           cache: ${{ inputs.cache }}
+      - name: provision (mise)
+        if: inputs.provisioner == 'mise'
+        uses: ./.github/actions/provision-mise
+        with:
+          cache: ${{ inputs.cache }}
       - name: run
         shell: bash
-        run: ${{ inputs.provisioner == 'flox' && 'flox activate -- ruff format --check .' || 'uvx ruff format --check .' }}
+        run: |
+          case "${{ inputs.provisioner }}" in
+            flox) flox activate -- ruff format --check . ;;
+            mise) mise exec -- ruff format --check . ;;
+            *)    uvx ruff format --check . ;;
+          esac
 
   ty:
     runs-on: ${{ inputs.os }}
@@ -69,14 +98,20 @@ jobs:
         uses: ./.github/actions/provision-flox
         with:
           cache: ${{ inputs.cache }}
+      - name: provision (mise)
+        if: inputs.provisioner == 'mise'
+        uses: ./.github/actions/provision-mise
+        with:
+          cache: ${{ inputs.cache }}
       - name: run
         shell: bash
         run: |
-          if [ "${{ inputs.provisioner }}" = "flox" ]; then
-            flox activate -- bash -c 'uv sync --group dev && uv run ty check py_launch_blueprint/'
-          else
-            uv sync --group dev && uv run ty check py_launch_blueprint/
-          fi
+          cmd='uv sync --group dev && uv run ty check py_launch_blueprint/'
+          case "${{ inputs.provisioner }}" in
+            flox) flox activate -- bash -c "$cmd" ;;
+            mise) mise exec -- bash -c "$cmd" ;;
+            *)    bash -c "$cmd" ;;
+          esac
 
   pytest:
     runs-on: ${{ inputs.os }}
@@ -93,14 +128,20 @@ jobs:
         uses: ./.github/actions/provision-flox
         with:
           cache: ${{ inputs.cache }}
+      - name: provision (mise)
+        if: inputs.provisioner == 'mise'
+        uses: ./.github/actions/provision-mise
+        with:
+          cache: ${{ inputs.cache }}
       - name: run
         shell: bash
         run: |
-          if [ "${{ inputs.provisioner }}" = "flox" ]; then
-            flox activate -- bash -c 'uv sync --group dev && uv run pytest -m "" --cov=py_launch_blueprint --cov-report=xml'
-          else
-            uv sync --group dev && uv run pytest -m "" --cov=py_launch_blueprint --cov-report=xml
-          fi
+          cmd='uv sync --group dev && uv run pytest -m "" --cov=py_launch_blueprint --cov-report=xml'
+          case "${{ inputs.provisioner }}" in
+            flox) flox activate -- bash -c "$cmd" ;;
+            mise) mise exec -- bash -c "$cmd" ;;
+            *)    bash -c "$cmd" ;;
+          esac
 
   taplo:
     runs-on: ${{ inputs.os }}
@@ -117,14 +158,19 @@ jobs:
         uses: ./.github/actions/provision-flox
         with:
           cache: ${{ inputs.cache }}
+      - name: provision (mise)
+        if: inputs.provisioner == 'mise'
+        uses: ./.github/actions/provision-mise
+        with:
+          cache: ${{ inputs.cache }}
       - name: run
         shell: bash
         run: |
-          if [ "${{ inputs.provisioner }}" = "flox" ]; then
-            flox activate -- taplo check '**/*.toml'
-          else
-            taplo check '**/*.toml'
-          fi
+          case "${{ inputs.provisioner }}" in
+            flox) flox activate -- taplo check '**/*.toml' ;;
+            mise) mise exec -- taplo check '**/*.toml' ;;
+            *)    taplo check '**/*.toml' ;;
+          esac
 
   codespell:
     runs-on: ${{ inputs.os }}
@@ -141,9 +187,19 @@ jobs:
         uses: ./.github/actions/provision-flox
         with:
           cache: ${{ inputs.cache }}
+      - name: provision (mise)
+        if: inputs.provisioner == 'mise'
+        uses: ./.github/actions/provision-mise
+        with:
+          cache: ${{ inputs.cache }}
       - name: run
         shell: bash
-        run: ${{ inputs.provisioner == 'flox' && 'flox activate -- codespell --toml pyproject.toml' || 'uvx codespell --toml pyproject.toml' }}
+        run: |
+          case "${{ inputs.provisioner }}" in
+            flox) flox activate -- codespell --toml pyproject.toml ;;
+            mise) mise exec -- codespell --toml pyproject.toml ;;
+            *)    uvx codespell --toml pyproject.toml ;;
+          esac
 
   yamllint:
     runs-on: ${{ inputs.os }}
@@ -160,28 +216,19 @@ jobs:
         uses: ./.github/actions/provision-flox
         with:
           cache: ${{ inputs.cache }}
-      - name: run
-        shell: bash
-        run: ${{ inputs.provisioner == 'flox' && 'flox activate -- yamllint -c .yamllint .' || 'uvx yamllint -c .yamllint .' }}
-
-  editorconfig:
-    runs-on: ${{ inputs.os }}
-    steps:
-      - uses: actions/checkout@v6
-      - name: provision (traditional)
-        if: inputs.provisioner == 'traditional'
-        uses: ./.github/actions/provision-traditional
-        with:
-          tools: bun
-          cache: ${{ inputs.cache }}
-      - name: provision (flox)
-        if: inputs.provisioner == 'flox'
-        uses: ./.github/actions/provision-flox
+      - name: provision (mise)
+        if: inputs.provisioner == 'mise'
+        uses: ./.github/actions/provision-mise
         with:
           cache: ${{ inputs.cache }}
       - name: run
         shell: bash
-        run: ${{ inputs.provisioner == 'flox' && 'flox activate -- editorconfig-checker --config .editorconfig-checker.json' || 'bunx --bun editorconfig-checker --config .editorconfig-checker.json' }}
+        run: |
+          case "${{ inputs.provisioner }}" in
+            flox) flox activate -- yamllint -c .yamllint . ;;
+            mise) mise exec -- yamllint -c .yamllint . ;;
+            *)    uvx yamllint -c .yamllint . ;;
+          esac
 
   bandit:
     runs-on: ${{ inputs.os }}
@@ -198,9 +245,19 @@ jobs:
         uses: ./.github/actions/provision-flox
         with:
           cache: ${{ inputs.cache }}
+      - name: provision (mise)
+        if: inputs.provisioner == 'mise'
+        uses: ./.github/actions/provision-mise
+        with:
+          cache: ${{ inputs.cache }}
       - name: run
         shell: bash
-        run: ${{ inputs.provisioner == 'flox' && 'flox activate -- bandit -r py_launch_blueprint/ -c pyproject.toml' || 'uvx bandit -r py_launch_blueprint/ -c pyproject.toml' }}
+        run: |
+          case "${{ inputs.provisioner }}" in
+            flox) flox activate -- bandit -r py_launch_blueprint/ -c pyproject.toml ;;
+            mise) mise exec -- bandit -r py_launch_blueprint/ -c pyproject.toml ;;
+            *)    uvx bandit -r py_launch_blueprint/ -c pyproject.toml ;;
+          esac
 
   gitleaks:
     runs-on: ${{ inputs.os }}
@@ -219,9 +276,19 @@ jobs:
         uses: ./.github/actions/provision-flox
         with:
           cache: ${{ inputs.cache }}
+      - name: provision (mise)
+        if: inputs.provisioner == 'mise'
+        uses: ./.github/actions/provision-mise
+        with:
+          cache: ${{ inputs.cache }}
       - name: run
         shell: bash
-        run: ${{ inputs.provisioner == 'flox' && 'flox activate -- gitleaks detect --source . --no-banner' || 'gitleaks detect --source . --no-banner' }}
+        run: |
+          case "${{ inputs.provisioner }}" in
+            flox) flox activate -- gitleaks detect --source . --config .gitleaks.toml --no-banner ;;
+            mise) mise exec -- gitleaks detect --source . --config .gitleaks.toml --no-banner ;;
+            *)    gitleaks detect --source . --config .gitleaks.toml --no-banner ;;
+          esac
 
   commitlint:
     runs-on: ${{ inputs.os }}
@@ -240,6 +307,16 @@ jobs:
         uses: ./.github/actions/provision-flox
         with:
           cache: ${{ inputs.cache }}
+      - name: provision (mise)
+        if: inputs.provisioner == 'mise'
+        uses: ./.github/actions/provision-mise
+        with:
+          cache: ${{ inputs.cache }}
       - name: run
         shell: bash
-        run: ${{ inputs.provisioner == 'flox' && 'flox activate -- commitlint --from=HEAD~10 --to=HEAD' || 'bunx --bun commitlint --from=HEAD~10 --to=HEAD' }}
+        run: |
+          case "${{ inputs.provisioner }}" in
+            flox) flox activate -- commitlint --from=HEAD~10 --to=HEAD ;;
+            mise) mise exec -- commitlint --from=HEAD~10 --to=HEAD ;;
+            *)    bunx --bun commitlint --from=HEAD~10 --to=HEAD ;;
+          esac

--- a/.github/workflows/flox-consolidated.yml
+++ b/.github/workflows/flox-consolidated.yml
@@ -33,9 +33,8 @@ jobs:
             taplo check "**/*.toml"
             codespell --toml pyproject.toml
             yamllint -c .yamllint .
-            editorconfig-checker --config .editorconfig-checker.json
             bandit -r py_launch_blueprint/ -c pyproject.toml
-            gitleaks detect --source . --no-banner
+            gitleaks detect --source . --config .gitleaks.toml --no-banner
             commitlint --from=HEAD~10 --to=HEAD
           '
 

--- a/.github/workflows/mise-consolidated.yml
+++ b/.github/workflows/mise-consolidated.yml
@@ -1,0 +1,51 @@
+name: mise-consolidated
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        type: string
+        required: true
+      cache:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  hygiene:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: provision (mise)
+        uses: ./.github/actions/provision-mise
+        with:
+          cache: ${{ inputs.cache }}
+      - name: all hygiene checks under one mise env
+        shell: bash
+        run: |
+          mise exec -- bash -euo pipefail -c '
+            ruff check .
+            ruff format --check .
+            uv sync --group dev && uv run ty check py_launch_blueprint/
+            taplo check "**/*.toml"
+            codespell --toml pyproject.toml
+            yamllint -c .yamllint .
+            bandit -r py_launch_blueprint/ -c pyproject.toml
+            gitleaks detect --source . --config .gitleaks.toml --no-banner
+            commitlint --from=HEAD~10 --to=HEAD
+          '
+
+  pytest:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: provision (mise)
+        uses: ./.github/actions/provision-mise
+        with:
+          cache: ${{ inputs.cache }}
+      - name: tests under one mise env
+        shell: bash
+        run: mise exec -- bash -c 'uv sync --group dev && uv run pytest -m "" --cov=py_launch_blueprint --cov-report=xml'

--- a/.github/workflows/mise-suite.yml
+++ b/.github/workflows/mise-suite.yml
@@ -1,0 +1,21 @@
+name: mise-suite
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        type: string
+        required: true
+      cache:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    uses: ./.github/workflows/_checks.yml
+    with:
+      provisioner: mise
+      os: ${{ inputs.os }}
+      cache: ${{ inputs.cache }}

--- a/init/manifest.toml
+++ b/init/manifest.toml
@@ -118,12 +118,12 @@ files   = [
 ]
 mode    = "structured"
 
-# package_name (text) — 85 occurrences in 31 files
+# package_name (text) — 84 occurrences in 31 files
 [[replace]]
 field   = "package_name"
 current = ["py_launch_blueprint"]
 files   = [
-  ".github/workflows/_checks.yml",   # 6x
+  ".github/workflows/_checks.yml",   # 5x
   ".github/workflows/bandit.yml",   # 1x
   ".github/workflows/ci.yml",   # 2x
   ".github/workflows/flox-consolidated.yml",   # 3x

--- a/init/manifest.toml
+++ b/init/manifest.toml
@@ -118,7 +118,7 @@ files   = [
 ]
 mode    = "structured"
 
-# package_name (text) — 82 occurrences in 30 files
+# package_name (text) — 85 occurrences in 31 files
 [[replace]]
 field   = "package_name"
 current = ["py_launch_blueprint"]
@@ -127,6 +127,7 @@ files   = [
   ".github/workflows/bandit.yml",   # 1x
   ".github/workflows/ci.yml",   # 2x
   ".github/workflows/flox-consolidated.yml",   # 3x
+  ".github/workflows/mise-consolidated.yml",   # 3x
   ".vscode/launch.json",   # 2x
   ".windsurfrules",   # 1x
   "AGENTS.md",   # 1x


### PR DESCRIPTION
## What
Adds the **dispatch-only** workflows + composite action for the **mise** side of the
Flox-vs-traditional-vs-mise CI timing experiment, so they can be triggered.

Same mechanism as the earlier flox PR: `workflow_dispatch`-only workflows must exist on
the default branch to be triggerable. The full harness (the 3-way `_checks.yml`,
`experiment/mise.toml`, analysis) lives on branch `experiment/flox-ci-timing` and is what
runs when dispatched with `--ref experiment/flox-ci-timing`.

## Footprint on main
`workflow_dispatch`-only — never runs on push/PR. No change to normal CI.

## Files
- `.github/workflows/mise-suite.yml` — mise-mirror caller (`provisioner: mise`)
- `.github/workflows/mise-consolidated.yml` — one mise env, all checks
- `.github/actions/provision-mise/` — installs mise + toolchain via `jdx/mise-action`
- `init/manifest.toml` — register `mise-consolidated.yml` (contains `py_launch_blueprint`)

## After merge
```
gh workflow run mise-suite.yml --ref experiment/flox-ci-timing -f os=ubuntu-latest -f cache=cold
```
runs the branch's mise side. Adds mise as a third provisioning model alongside traditional
and flox in ADR-12's analysis.
