### PR TITLE
ci: enable dispatch-only flox-nocache (use-cache=false) experiment workflows

### DIFF
--- a/.github/actions/provision-flox/action.yml
+++ b/.github/actions/provision-flox/action.yml
@@ -14,7 +14,8 @@ runs:
     - name: Install Flox
       uses: flox/install-flox-action@v2
       with:
-        use-cache: ${{ inputs.use-cache }}
+        # bracket notation: `inputs.use-cache` would parse as subtraction (use - cache)
+        use-cache: ${{ inputs['use-cache'] }}
     - name: Cache Nix store
       uses: actions/cache@v4
       with:

--- a/.github/actions/provision-flox/action.yml
+++ b/.github/actions/provision-flox/action.yml
@@ -4,11 +4,17 @@ inputs:
   cache:
     description: cold | warm
     required: true
+  use-cache:
+    description: pass-through to flox/install-flox-action (caches the flox CLI binary)
+    required: false
+    default: "true"
 runs:
   using: composite
   steps:
     - name: Install Flox
       uses: flox/install-flox-action@v2
+      with:
+        use-cache: ${{ inputs.use-cache }}
     - name: Cache Nix store
       uses: actions/cache@v4
       with:

--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -36,10 +36,11 @@ jobs:
           tools: uv
           cache: ${{ inputs.cache }}
       - name: provision (flox)
-        if: inputs.provisioner == 'flox'
+        if: inputs.provisioner == 'flox' || inputs.provisioner == 'flox-nocache'
         uses: ./.github/actions/provision-flox
         with:
           cache: ${{ inputs.cache }}
+          use-cache: ${{ inputs.provisioner == 'flox-nocache' && 'false' || 'true' }}
       - name: provision (mise)
         if: inputs.provisioner == 'mise'
         uses: ./.github/actions/provision-mise
@@ -49,7 +50,7 @@ jobs:
         shell: bash
         run: |
           case "${{ inputs.provisioner }}" in
-            flox) flox activate -- ruff check . ;;
+            flox | flox-nocache) flox activate -- ruff check . ;;
             mise) mise exec -- ruff check . ;;
             *)    uvx ruff check . ;;
           esac
@@ -65,10 +66,11 @@ jobs:
           tools: uv
           cache: ${{ inputs.cache }}
       - name: provision (flox)
-        if: inputs.provisioner == 'flox'
+        if: inputs.provisioner == 'flox' || inputs.provisioner == 'flox-nocache'
         uses: ./.github/actions/provision-flox
         with:
           cache: ${{ inputs.cache }}
+          use-cache: ${{ inputs.provisioner == 'flox-nocache' && 'false' || 'true' }}
       - name: provision (mise)
         if: inputs.provisioner == 'mise'
         uses: ./.github/actions/provision-mise
@@ -78,7 +80,7 @@ jobs:
         shell: bash
         run: |
           case "${{ inputs.provisioner }}" in
-            flox) flox activate -- ruff format --check . ;;
+            flox | flox-nocache) flox activate -- ruff format --check . ;;
             mise) mise exec -- ruff format --check . ;;
             *)    uvx ruff format --check . ;;
           esac
@@ -94,10 +96,11 @@ jobs:
           tools: uv
           cache: ${{ inputs.cache }}
       - name: provision (flox)
-        if: inputs.provisioner == 'flox'
+        if: inputs.provisioner == 'flox' || inputs.provisioner == 'flox-nocache'
         uses: ./.github/actions/provision-flox
         with:
           cache: ${{ inputs.cache }}
+          use-cache: ${{ inputs.provisioner == 'flox-nocache' && 'false' || 'true' }}
       - name: provision (mise)
         if: inputs.provisioner == 'mise'
         uses: ./.github/actions/provision-mise
@@ -108,7 +111,7 @@ jobs:
         run: |
           cmd='uv sync --group dev && uv run ty check py_launch_blueprint/'
           case "${{ inputs.provisioner }}" in
-            flox) flox activate -- bash -c "$cmd" ;;
+            flox | flox-nocache) flox activate -- bash -c "$cmd" ;;
             mise) mise exec -- bash -c "$cmd" ;;
             *)    bash -c "$cmd" ;;
           esac
@@ -124,10 +127,11 @@ jobs:
           tools: uv
           cache: ${{ inputs.cache }}
       - name: provision (flox)
-        if: inputs.provisioner == 'flox'
+        if: inputs.provisioner == 'flox' || inputs.provisioner == 'flox-nocache'
         uses: ./.github/actions/provision-flox
         with:
           cache: ${{ inputs.cache }}
+          use-cache: ${{ inputs.provisioner == 'flox-nocache' && 'false' || 'true' }}
       - name: provision (mise)
         if: inputs.provisioner == 'mise'
         uses: ./.github/actions/provision-mise
@@ -138,7 +142,7 @@ jobs:
         run: |
           cmd='uv sync --group dev && uv run pytest -m "" --cov=py_launch_blueprint --cov-report=xml'
           case "${{ inputs.provisioner }}" in
-            flox) flox activate -- bash -c "$cmd" ;;
+            flox | flox-nocache) flox activate -- bash -c "$cmd" ;;
             mise) mise exec -- bash -c "$cmd" ;;
             *)    bash -c "$cmd" ;;
           esac
@@ -154,10 +158,11 @@ jobs:
           tools: just
           cache: ${{ inputs.cache }}
       - name: provision (flox)
-        if: inputs.provisioner == 'flox'
+        if: inputs.provisioner == 'flox' || inputs.provisioner == 'flox-nocache'
         uses: ./.github/actions/provision-flox
         with:
           cache: ${{ inputs.cache }}
+          use-cache: ${{ inputs.provisioner == 'flox-nocache' && 'false' || 'true' }}
       - name: provision (mise)
         if: inputs.provisioner == 'mise'
         uses: ./.github/actions/provision-mise
@@ -167,7 +172,7 @@ jobs:
         shell: bash
         run: |
           case "${{ inputs.provisioner }}" in
-            flox) flox activate -- taplo check '**/*.toml' ;;
+            flox | flox-nocache) flox activate -- taplo check '**/*.toml' ;;
             mise) mise exec -- taplo check '**/*.toml' ;;
             *)    taplo check '**/*.toml' ;;
           esac
@@ -183,10 +188,11 @@ jobs:
           tools: uv
           cache: ${{ inputs.cache }}
       - name: provision (flox)
-        if: inputs.provisioner == 'flox'
+        if: inputs.provisioner == 'flox' || inputs.provisioner == 'flox-nocache'
         uses: ./.github/actions/provision-flox
         with:
           cache: ${{ inputs.cache }}
+          use-cache: ${{ inputs.provisioner == 'flox-nocache' && 'false' || 'true' }}
       - name: provision (mise)
         if: inputs.provisioner == 'mise'
         uses: ./.github/actions/provision-mise
@@ -196,7 +202,7 @@ jobs:
         shell: bash
         run: |
           case "${{ inputs.provisioner }}" in
-            flox) flox activate -- codespell --toml pyproject.toml ;;
+            flox | flox-nocache) flox activate -- codespell --toml pyproject.toml ;;
             mise) mise exec -- codespell --toml pyproject.toml ;;
             *)    uvx codespell --toml pyproject.toml ;;
           esac
@@ -212,10 +218,11 @@ jobs:
           tools: uv
           cache: ${{ inputs.cache }}
       - name: provision (flox)
-        if: inputs.provisioner == 'flox'
+        if: inputs.provisioner == 'flox' || inputs.provisioner == 'flox-nocache'
         uses: ./.github/actions/provision-flox
         with:
           cache: ${{ inputs.cache }}
+          use-cache: ${{ inputs.provisioner == 'flox-nocache' && 'false' || 'true' }}
       - name: provision (mise)
         if: inputs.provisioner == 'mise'
         uses: ./.github/actions/provision-mise
@@ -225,7 +232,7 @@ jobs:
         shell: bash
         run: |
           case "${{ inputs.provisioner }}" in
-            flox) flox activate -- yamllint -c .yamllint . ;;
+            flox | flox-nocache) flox activate -- yamllint -c .yamllint . ;;
             mise) mise exec -- yamllint -c .yamllint . ;;
             *)    uvx yamllint -c .yamllint . ;;
           esac
@@ -241,10 +248,11 @@ jobs:
           tools: uv
           cache: ${{ inputs.cache }}
       - name: provision (flox)
-        if: inputs.provisioner == 'flox'
+        if: inputs.provisioner == 'flox' || inputs.provisioner == 'flox-nocache'
         uses: ./.github/actions/provision-flox
         with:
           cache: ${{ inputs.cache }}
+          use-cache: ${{ inputs.provisioner == 'flox-nocache' && 'false' || 'true' }}
       - name: provision (mise)
         if: inputs.provisioner == 'mise'
         uses: ./.github/actions/provision-mise
@@ -254,7 +262,7 @@ jobs:
         shell: bash
         run: |
           case "${{ inputs.provisioner }}" in
-            flox) flox activate -- bandit -r py_launch_blueprint/ -c pyproject.toml ;;
+            flox | flox-nocache) flox activate -- bandit -r py_launch_blueprint/ -c pyproject.toml ;;
             mise) mise exec -- bandit -r py_launch_blueprint/ -c pyproject.toml ;;
             *)    uvx bandit -r py_launch_blueprint/ -c pyproject.toml ;;
           esac
@@ -272,10 +280,11 @@ jobs:
           tools: gitleaks
           cache: ${{ inputs.cache }}
       - name: provision (flox)
-        if: inputs.provisioner == 'flox'
+        if: inputs.provisioner == 'flox' || inputs.provisioner == 'flox-nocache'
         uses: ./.github/actions/provision-flox
         with:
           cache: ${{ inputs.cache }}
+          use-cache: ${{ inputs.provisioner == 'flox-nocache' && 'false' || 'true' }}
       - name: provision (mise)
         if: inputs.provisioner == 'mise'
         uses: ./.github/actions/provision-mise
@@ -285,7 +294,7 @@ jobs:
         shell: bash
         run: |
           case "${{ inputs.provisioner }}" in
-            flox) flox activate -- gitleaks detect --source . --config .gitleaks.toml --no-banner ;;
+            flox | flox-nocache) flox activate -- gitleaks detect --source . --config .gitleaks.toml --no-banner ;;
             mise) mise exec -- gitleaks detect --source . --config .gitleaks.toml --no-banner ;;
             *)    gitleaks detect --source . --config .gitleaks.toml --no-banner ;;
           esac
@@ -303,10 +312,11 @@ jobs:
           tools: bun
           cache: ${{ inputs.cache }}
       - name: provision (flox)
-        if: inputs.provisioner == 'flox'
+        if: inputs.provisioner == 'flox' || inputs.provisioner == 'flox-nocache'
         uses: ./.github/actions/provision-flox
         with:
           cache: ${{ inputs.cache }}
+          use-cache: ${{ inputs.provisioner == 'flox-nocache' && 'false' || 'true' }}
       - name: provision (mise)
         if: inputs.provisioner == 'mise'
         uses: ./.github/actions/provision-mise
@@ -316,7 +326,9 @@ jobs:
         shell: bash
         run: |
           case "${{ inputs.provisioner }}" in
-            flox) flox activate -- commitlint --from=HEAD~10 --to=HEAD ;;
-            mise) mise exec -- commitlint --from=HEAD~10 --to=HEAD ;;
+            flox | flox-nocache) flox activate -- commitlint --from=HEAD~10 --to=HEAD ;;
+            # mise's isolated commitlint can't see @commitlint/config-conventional
+            # (a repo devDep); bun (from mise) installs it, then mise commitlint runs.
+            mise) mise exec -- bash -c 'bun install && commitlint --from=HEAD~10 --to=HEAD' ;;
             *)    bunx --bun commitlint --from=HEAD~10 --to=HEAD ;;
           esac

--- a/.github/workflows/experiment-driver.yml
+++ b/.github/workflows/experiment-driver.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       sides:
-        description: subset of traditional,flox-mirror,flox-consolidated,mise-mirror,mise-consolidated,flox-nocache-mirror,flox-nocache-consolidated
+        description: comma-separated subset of traditional,flox-mirror,flox-consolidated,mise-mirror,mise-consolidated,flox-nocache-mirror,flox-nocache-consolidated
         type: string
         default: traditional,flox-mirror,flox-consolidated,mise-mirror,mise-consolidated
       oses:

--- a/.github/workflows/experiment-driver.yml
+++ b/.github/workflows/experiment-driver.yml
@@ -3,9 +3,9 @@ on:
   workflow_dispatch:
     inputs:
       sides:
-        description: comma-separated subset of traditional,flox-mirror,flox-consolidated
+        description: subset of traditional,flox-mirror,flox-consolidated,mise-mirror,mise-consolidated,flox-nocache-mirror,flox-nocache-consolidated
         type: string
-        default: traditional,flox-mirror,flox-consolidated
+        default: traditional,flox-mirror,flox-consolidated,mise-mirror,mise-consolidated
       oses:
         description: comma-separated subset of ubuntu-latest,macos-latest
         type: string
@@ -54,7 +54,9 @@ jobs:
             before=$(gh run list --workflow="${wfname}.yml" --branch "$REF" \
               --event workflow_dispatch --limit 60 --json databaseId \
               -q '[.[].databaseId] | join(" ")')
-            gh workflow run "${wfname}.yml" --ref "$REF" -f os="$os" -f cache="$cache"
+            # 1>&2: `gh workflow run` prints the run URL to stdout; redirect it to
+            # stderr so it doesn't pollute this function's stdout (the returned id).
+            gh workflow run "${wfname}.yml" --ref "$REF" -f os="$os" -f cache="$cache" 1>&2
             for _ in $(seq 1 30); do
               sleep 6
               for id in $(gh run list --workflow="${wfname}.yml" --branch "$REF" \
@@ -75,6 +77,10 @@ jobs:
               traditional) wf="trad-suite" ;;
               flox-mirror) wf="flox-mirror-suite" ;;
               flox-consolidated) wf="flox-consolidated" ;;
+              mise-mirror) wf="mise-suite" ;;
+              mise-consolidated) wf="mise-consolidated" ;;
+              flox-nocache-mirror) wf="flox-nocache-suite" ;;
+              flox-nocache-consolidated) wf="flox-nocache-consolidated" ;;
               *) echo "unknown side: $side" >&2; exit 1 ;;
             esac
             for os in "${OS_ARR[@]}"; do

--- a/.github/workflows/flox-nocache-consolidated.yml
+++ b/.github/workflows/flox-nocache-consolidated.yml
@@ -1,0 +1,56 @@
+name: flox-nocache-consolidated
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        type: string
+        required: true
+      cache:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+# Same as flox-consolidated, but flox/install-flox-action use-cache: "false"
+# (the flox CLI binary is NOT cached — A/B against flox-consolidated).
+
+jobs:
+  hygiene:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: provision (flox)
+        uses: ./.github/actions/provision-flox
+        with:
+          cache: ${{ inputs.cache }}
+          use-cache: "false"
+      - name: all hygiene checks under one activation
+        shell: bash
+        run: |
+          flox activate -- bash -euo pipefail -c '
+            ruff check .
+            ruff format --check .
+            uv sync --group dev && uv run ty check py_launch_blueprint/
+            taplo check "**/*.toml"
+            codespell --toml pyproject.toml
+            yamllint -c .yamllint .
+            bandit -r py_launch_blueprint/ -c pyproject.toml
+            gitleaks detect --source . --config .gitleaks.toml --no-banner
+            commitlint --from=HEAD~10 --to=HEAD
+          '
+
+  pytest:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: provision (flox)
+        uses: ./.github/actions/provision-flox
+        with:
+          cache: ${{ inputs.cache }}
+          use-cache: "false"
+      - name: tests under one activation
+        shell: bash
+        run: flox activate -- bash -c 'uv sync --group dev && uv run pytest -m "" --cov=py_launch_blueprint --cov-report=xml'

--- a/.github/workflows/flox-nocache-suite.yml
+++ b/.github/workflows/flox-nocache-suite.yml
@@ -1,0 +1,21 @@
+name: flox-nocache-suite
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        type: string
+        required: true
+      cache:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    uses: ./.github/workflows/_checks.yml
+    with:
+      provisioner: flox-nocache
+      os: ${{ inputs.os }}
+      cache: ${{ inputs.cache }}

--- a/init/manifest.toml
+++ b/init/manifest.toml
@@ -118,7 +118,7 @@ files   = [
 ]
 mode    = "structured"
 
-# package_name (text) — 84 occurrences in 31 files
+# package_name (text) — 87 occurrences in 32 files
 [[replace]]
 field   = "package_name"
 current = ["py_launch_blueprint"]
@@ -127,6 +127,7 @@ files   = [
   ".github/workflows/bandit.yml",   # 1x
   ".github/workflows/ci.yml",   # 2x
   ".github/workflows/flox-consolidated.yml",   # 3x
+  ".github/workflows/flox-nocache-consolidated.yml",   # 3x
   ".github/workflows/mise-consolidated.yml",   # 3x
   ".vscode/launch.json",   # 2x
   ".windsurfrules",   # 1x


### PR DESCRIPTION
## What
Adds the **dispatch-only** `flox-nocache` workflows to `main` so they can be triggered —
a new experiment dimension: `flox/install-flox-action` with **`use-cache: "false"`** (the
flox CLI binary is NOT cached), A/B against the existing `flox` sides.

Same mechanism as the prior flox/mise PRs: `workflow_dispatch`-only workflows must exist on
the default branch. The harness runs from branch `experiment/flox-ci-timing-perf-analysis`
when dispatched with `--ref experiment/flox-ci-timing-perf-analysis`.

## Footprint on main
`workflow_dispatch`-only — never runs on push/PR. No change to normal CI.

## Files
- `.github/workflows/flox-nocache-suite.yml` — flox-nocache mirror caller
- `.github/workflows/flox-nocache-consolidated.yml` — flox-nocache, one activation
- `.github/actions/provision-flox/` — gains a `use-cache` input (pass-through to
  flox/install-flox-action; required so `flox-nocache-consolidated`'s `with: use-cache` is valid)
- `.github/workflows/_checks.yml` — flox provision step + run-cases handle `flox-nocache`
- `.github/workflows/experiment-driver.yml` — driver mapping for the new sides
- `init/manifest.toml` — register `flox-nocache-consolidated.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add an option to provision environments without caching and new manual workflows to run non-cached test and hygiene suites.

* **Chores**
  * Update CI dispatch and checks to support the non-cached provisioner, adjust workflow inputs and mappings, and ensure required tooling is installed prior to linting/commit checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->