### PR TITLE
ci: add dispatch-only flox-noaction workflows

### DIFF
--- a/.github/actions/provision-flox-noaction/action.yml
+++ b/.github/actions/provision-flox-noaction/action.yml
@@ -1,0 +1,60 @@
+name: provision-flox-noaction
+description: Install Flox via direct package download (no GitHub Action) and restore/save the Nix store cache.
+inputs:
+  cache:
+    description: cold | warm
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Install Flox (no action — manual package install, pinned)
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Pinned to current stable; matches what flox/install-flox-action installs
+        # today. BUMP before running if stable advances past this (see spec caveat).
+        VER=1.12.2
+        case "${{ runner.os }}" in
+          Linux)
+            case "$(uname -m)" in
+              aarch64 | arm64) a=aarch64-linux ;;
+              *) a=x86_64-linux ;;
+            esac
+            url="https://downloads.flox.dev/by-env/stable/deb/flox-${VER}.${a}.deb"
+            curl -fsSL "$url" -o /tmp/flox.deb
+            sudo apt-get install -y /tmp/flox.deb
+            ;;
+          macOS)
+            case "$(uname -m)" in
+              arm64 | aarch64) a=aarch64-darwin ;;
+              *) a=x86_64-darwin ;;
+            esac
+            url="https://downloads.flox.dev/by-env/stable/osx/flox-${VER}.${a}.pkg"
+            curl -fsSL "$url" -o /tmp/flox.pkg
+            sudo installer -pkg /tmp/flox.pkg -target /
+            ;;
+          *)
+            echo "unsupported runner.os: ${{ runner.os }}" >&2
+            exit 1
+            ;;
+        esac
+        # Match install-flox-action: avoid first-run metrics prompt/behavior in CI.
+        flox config --set disable_metrics true
+        flox --version
+    - name: Cache Nix store
+      uses: actions/cache@v4
+      with:
+        path: |
+          /nix
+          ~/.cache/flox
+        # Own namespace (flox-noaction-) so it is measured independently and cannot
+        # cross-hit the action sides' caches. cold -> unique key (guaranteed miss);
+        # warm -> stable key per lock+os.
+        key: >-
+          flox-noaction-${{ inputs.cache }}-${{ runner.os }}-${{ hashFiles('.flox/env/manifest.lock') }}-${{
+            inputs.cache == 'cold' && github.run_id || 'stable' }}
+        restore-keys: |
+          ${{ inputs.cache == 'warm' && format('flox-noaction-warm-{0}-{1}-stable', runner.os, hashFiles('.flox/env/manifest.lock')) || 'flox-never-restore' }}
+    - name: Warm the flox env
+      shell: bash
+      run: flox activate -- true

--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -41,6 +41,11 @@ jobs:
         with:
           cache: ${{ inputs.cache }}
           use-cache: ${{ inputs.provisioner == 'flox-nocache' && 'false' || 'true' }}
+      - name: provision (flox)
+        if: inputs.provisioner == 'flox-noaction'
+        uses: ./.github/actions/provision-flox-noaction
+        with:
+          cache: ${{ inputs.cache }}
       - name: provision (mise)
         if: inputs.provisioner == 'mise'
         uses: ./.github/actions/provision-mise
@@ -50,7 +55,7 @@ jobs:
         shell: bash
         run: |
           case "${{ inputs.provisioner }}" in
-            flox | flox-nocache) flox activate -- ruff check . ;;
+            flox | flox-nocache | flox-noaction) flox activate -- ruff check . ;;
             mise) mise exec -- ruff check . ;;
             *)    uvx ruff check . ;;
           esac
@@ -71,6 +76,11 @@ jobs:
         with:
           cache: ${{ inputs.cache }}
           use-cache: ${{ inputs.provisioner == 'flox-nocache' && 'false' || 'true' }}
+      - name: provision (flox)
+        if: inputs.provisioner == 'flox-noaction'
+        uses: ./.github/actions/provision-flox-noaction
+        with:
+          cache: ${{ inputs.cache }}
       - name: provision (mise)
         if: inputs.provisioner == 'mise'
         uses: ./.github/actions/provision-mise
@@ -80,7 +90,7 @@ jobs:
         shell: bash
         run: |
           case "${{ inputs.provisioner }}" in
-            flox | flox-nocache) flox activate -- ruff format --check . ;;
+            flox | flox-nocache | flox-noaction) flox activate -- ruff format --check . ;;
             mise) mise exec -- ruff format --check . ;;
             *)    uvx ruff format --check . ;;
           esac
@@ -101,6 +111,11 @@ jobs:
         with:
           cache: ${{ inputs.cache }}
           use-cache: ${{ inputs.provisioner == 'flox-nocache' && 'false' || 'true' }}
+      - name: provision (flox)
+        if: inputs.provisioner == 'flox-noaction'
+        uses: ./.github/actions/provision-flox-noaction
+        with:
+          cache: ${{ inputs.cache }}
       - name: provision (mise)
         if: inputs.provisioner == 'mise'
         uses: ./.github/actions/provision-mise
@@ -111,7 +126,7 @@ jobs:
         run: |
           cmd='uv sync --group dev && uv run ty check py_launch_blueprint/'
           case "${{ inputs.provisioner }}" in
-            flox | flox-nocache) flox activate -- bash -c "$cmd" ;;
+            flox | flox-nocache | flox-noaction) flox activate -- bash -c "$cmd" ;;
             mise) mise exec -- bash -c "$cmd" ;;
             *)    bash -c "$cmd" ;;
           esac
@@ -132,6 +147,11 @@ jobs:
         with:
           cache: ${{ inputs.cache }}
           use-cache: ${{ inputs.provisioner == 'flox-nocache' && 'false' || 'true' }}
+      - name: provision (flox)
+        if: inputs.provisioner == 'flox-noaction'
+        uses: ./.github/actions/provision-flox-noaction
+        with:
+          cache: ${{ inputs.cache }}
       - name: provision (mise)
         if: inputs.provisioner == 'mise'
         uses: ./.github/actions/provision-mise
@@ -142,7 +162,7 @@ jobs:
         run: |
           cmd='uv sync --group dev && uv run pytest -m "" --cov=py_launch_blueprint --cov-report=xml'
           case "${{ inputs.provisioner }}" in
-            flox | flox-nocache) flox activate -- bash -c "$cmd" ;;
+            flox | flox-nocache | flox-noaction) flox activate -- bash -c "$cmd" ;;
             mise) mise exec -- bash -c "$cmd" ;;
             *)    bash -c "$cmd" ;;
           esac
@@ -163,6 +183,11 @@ jobs:
         with:
           cache: ${{ inputs.cache }}
           use-cache: ${{ inputs.provisioner == 'flox-nocache' && 'false' || 'true' }}
+      - name: provision (flox)
+        if: inputs.provisioner == 'flox-noaction'
+        uses: ./.github/actions/provision-flox-noaction
+        with:
+          cache: ${{ inputs.cache }}
       - name: provision (mise)
         if: inputs.provisioner == 'mise'
         uses: ./.github/actions/provision-mise
@@ -172,7 +197,7 @@ jobs:
         shell: bash
         run: |
           case "${{ inputs.provisioner }}" in
-            flox | flox-nocache) flox activate -- taplo check '**/*.toml' ;;
+            flox | flox-nocache | flox-noaction) flox activate -- taplo check '**/*.toml' ;;
             mise) mise exec -- taplo check '**/*.toml' ;;
             *)    taplo check '**/*.toml' ;;
           esac
@@ -193,6 +218,11 @@ jobs:
         with:
           cache: ${{ inputs.cache }}
           use-cache: ${{ inputs.provisioner == 'flox-nocache' && 'false' || 'true' }}
+      - name: provision (flox)
+        if: inputs.provisioner == 'flox-noaction'
+        uses: ./.github/actions/provision-flox-noaction
+        with:
+          cache: ${{ inputs.cache }}
       - name: provision (mise)
         if: inputs.provisioner == 'mise'
         uses: ./.github/actions/provision-mise
@@ -202,7 +232,7 @@ jobs:
         shell: bash
         run: |
           case "${{ inputs.provisioner }}" in
-            flox | flox-nocache) flox activate -- codespell --toml pyproject.toml ;;
+            flox | flox-nocache | flox-noaction) flox activate -- codespell --toml pyproject.toml ;;
             mise) mise exec -- codespell --toml pyproject.toml ;;
             *)    uvx codespell --toml pyproject.toml ;;
           esac
@@ -223,6 +253,11 @@ jobs:
         with:
           cache: ${{ inputs.cache }}
           use-cache: ${{ inputs.provisioner == 'flox-nocache' && 'false' || 'true' }}
+      - name: provision (flox)
+        if: inputs.provisioner == 'flox-noaction'
+        uses: ./.github/actions/provision-flox-noaction
+        with:
+          cache: ${{ inputs.cache }}
       - name: provision (mise)
         if: inputs.provisioner == 'mise'
         uses: ./.github/actions/provision-mise
@@ -232,7 +267,7 @@ jobs:
         shell: bash
         run: |
           case "${{ inputs.provisioner }}" in
-            flox | flox-nocache) flox activate -- yamllint -c .yamllint . ;;
+            flox | flox-nocache | flox-noaction) flox activate -- yamllint -c .yamllint . ;;
             mise) mise exec -- yamllint -c .yamllint . ;;
             *)    uvx yamllint -c .yamllint . ;;
           esac
@@ -253,6 +288,11 @@ jobs:
         with:
           cache: ${{ inputs.cache }}
           use-cache: ${{ inputs.provisioner == 'flox-nocache' && 'false' || 'true' }}
+      - name: provision (flox)
+        if: inputs.provisioner == 'flox-noaction'
+        uses: ./.github/actions/provision-flox-noaction
+        with:
+          cache: ${{ inputs.cache }}
       - name: provision (mise)
         if: inputs.provisioner == 'mise'
         uses: ./.github/actions/provision-mise
@@ -262,7 +302,7 @@ jobs:
         shell: bash
         run: |
           case "${{ inputs.provisioner }}" in
-            flox | flox-nocache) flox activate -- bandit -r py_launch_blueprint/ -c pyproject.toml ;;
+            flox | flox-nocache | flox-noaction) flox activate -- bandit -r py_launch_blueprint/ -c pyproject.toml ;;
             mise) mise exec -- bandit -r py_launch_blueprint/ -c pyproject.toml ;;
             *)    uvx bandit -r py_launch_blueprint/ -c pyproject.toml ;;
           esac
@@ -285,6 +325,11 @@ jobs:
         with:
           cache: ${{ inputs.cache }}
           use-cache: ${{ inputs.provisioner == 'flox-nocache' && 'false' || 'true' }}
+      - name: provision (flox)
+        if: inputs.provisioner == 'flox-noaction'
+        uses: ./.github/actions/provision-flox-noaction
+        with:
+          cache: ${{ inputs.cache }}
       - name: provision (mise)
         if: inputs.provisioner == 'mise'
         uses: ./.github/actions/provision-mise
@@ -294,7 +339,7 @@ jobs:
         shell: bash
         run: |
           case "${{ inputs.provisioner }}" in
-            flox | flox-nocache) flox activate -- gitleaks detect --source . --config .gitleaks.toml --no-banner ;;
+            flox | flox-nocache | flox-noaction) flox activate -- gitleaks detect --source . --config .gitleaks.toml --no-banner ;;
             mise) mise exec -- gitleaks detect --source . --config .gitleaks.toml --no-banner ;;
             *)    gitleaks detect --source . --config .gitleaks.toml --no-banner ;;
           esac
@@ -317,6 +362,11 @@ jobs:
         with:
           cache: ${{ inputs.cache }}
           use-cache: ${{ inputs.provisioner == 'flox-nocache' && 'false' || 'true' }}
+      - name: provision (flox)
+        if: inputs.provisioner == 'flox-noaction'
+        uses: ./.github/actions/provision-flox-noaction
+        with:
+          cache: ${{ inputs.cache }}
       - name: provision (mise)
         if: inputs.provisioner == 'mise'
         uses: ./.github/actions/provision-mise
@@ -326,7 +376,7 @@ jobs:
         shell: bash
         run: |
           case "${{ inputs.provisioner }}" in
-            flox | flox-nocache) flox activate -- commitlint --from=HEAD~10 --to=HEAD ;;
+            flox | flox-nocache | flox-noaction) flox activate -- commitlint --from=HEAD~10 --to=HEAD ;;
             # mise's isolated commitlint can't see @commitlint/config-conventional
             # (a repo devDep); bun (from mise) installs it, then mise commitlint runs.
             mise) mise exec -- bash -c 'bun install && commitlint --from=HEAD~10 --to=HEAD' ;;

--- a/.github/workflows/experiment-driver.yml
+++ b/.github/workflows/experiment-driver.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       sides:
-        description: comma-separated subset of traditional,flox-mirror,flox-consolidated,mise-mirror,mise-consolidated,flox-nocache-mirror,flox-nocache-consolidated
+        description: comma-separated subset of traditional,flox-mirror,flox-consolidated,mise-mirror,mise-consolidated,flox-nocache-mirror,flox-nocache-consolidated,flox-noaction-mirror,flox-noaction-consolidated
         type: string
         default: traditional,flox-mirror,flox-consolidated,mise-mirror,mise-consolidated
       oses:
@@ -81,6 +81,8 @@ jobs:
               mise-consolidated) wf="mise-consolidated" ;;
               flox-nocache-mirror) wf="flox-nocache-suite" ;;
               flox-nocache-consolidated) wf="flox-nocache-consolidated" ;;
+              flox-noaction-mirror) wf="flox-noaction-suite" ;;
+              flox-noaction-consolidated) wf="flox-noaction-consolidated" ;;
               *) echo "unknown side: $side" >&2; exit 1 ;;
             esac
             for os in "${OS_ARR[@]}"; do
@@ -123,7 +125,7 @@ jobs:
           done
           echo "$collect" > run-ids.json
           cat run-ids.json
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@v4
         with:
           name: experiment-run-ids
           path: run-ids.json

--- a/.github/workflows/flox-noaction-consolidated.yml
+++ b/.github/workflows/flox-noaction-consolidated.yml
@@ -1,0 +1,54 @@
+name: flox-noaction-consolidated
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        type: string
+        required: true
+      cache:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+# Same as flox-consolidated, but flox is installed by direct package download
+# (no flox/install-flox-action — A/B against flox-consolidated / flox-nocache-consolidated).
+
+jobs:
+  hygiene:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: provision (flox)
+        uses: ./.github/actions/provision-flox-noaction
+        with:
+          cache: ${{ inputs.cache }}
+      - name: all hygiene checks under one activation
+        shell: bash
+        run: |
+          flox activate -- bash -euo pipefail -c '
+            ruff check .
+            ruff format --check .
+            uv sync --group dev && uv run ty check py_launch_blueprint/
+            taplo check "**/*.toml"
+            codespell --toml pyproject.toml
+            yamllint -c .yamllint .
+            bandit -r py_launch_blueprint/ -c pyproject.toml
+            gitleaks detect --source . --config .gitleaks.toml --no-banner
+            commitlint --from=HEAD~10 --to=HEAD
+          '
+
+  pytest:
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: provision (flox)
+        uses: ./.github/actions/provision-flox-noaction
+        with:
+          cache: ${{ inputs.cache }}
+      - name: tests under one activation
+        shell: bash
+        run: flox activate -- bash -c 'uv sync --group dev && uv run pytest -m "" --cov=py_launch_blueprint --cov-report=xml'

--- a/.github/workflows/flox-noaction-suite.yml
+++ b/.github/workflows/flox-noaction-suite.yml
@@ -1,0 +1,21 @@
+name: flox-noaction-suite
+on:
+  workflow_dispatch:
+    inputs:
+      os:
+        type: string
+        required: true
+      cache:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    uses: ./.github/workflows/_checks.yml
+    with:
+      provisioner: flox-noaction
+      os: ${{ inputs.os }}
+      cache: ${{ inputs.cache }}

--- a/init/manifest.toml
+++ b/init/manifest.toml
@@ -118,7 +118,7 @@ files   = [
 ]
 mode    = "structured"
 
-# package_name (text) — 87 occurrences in 32 files
+# package_name (text) — 90 occurrences in 33 files
 [[replace]]
 field   = "package_name"
 current = ["py_launch_blueprint"]
@@ -128,6 +128,7 @@ files   = [
   ".github/workflows/ci.yml",   # 2x
   ".github/workflows/flox-consolidated.yml",   # 3x
   ".github/workflows/flox-nocache-consolidated.yml",   # 3x
+  ".github/workflows/flox-noaction-consolidated.yml",   # 3x
   ".github/workflows/mise-consolidated.yml",   # 3x
   ".vscode/launch.json",   # 2x
   ".windsurfrules",   # 1x


### PR DESCRIPTION
## What
Adds the **dispatch-only** `flox-noaction` workflows to `main` so the experiment driver can dispatch them — the third layer of the flox provisioning decomposition.

`flox-noaction` installs flox by **direct package download** (pinned `.deb`/`.pkg` from downloads.flox.dev, v1.12.2) with **no** `flox/install-flox-action`. This isolates the action-wrapper cost:

| Config | Install | flox-binary cache |
|--------|---------|-------------------|
| `flox` | install-flox-action, use-cache=true | cached |
| `flox-nocache` | install-flox-action, use-cache=false | downloaded each run |
| `flox-noaction` (new) | manual `.deb`/`.pkg` | downloaded each run |

`flox` → `flox-nocache` peels off the binary cache; `flox-nocache` → `flox-noaction` peels off the action wrapper.

## Footprint on main
`workflow_dispatch`-only — never runs on push/PR. No change to normal CI. The harness executes the branch versions via `--ref experiment/flox-ci-timing-perf-analysis`; these entry workflows must exist on `main` to be dispatchable.

## Files
- `.github/actions/provision-flox-noaction/action.yml` — manual pinned install (per-OS arch-detected) + own `flox-noaction-` Nix cache namespace
- `.github/workflows/flox-noaction-suite.yml` — mirror caller (provisioner=flox-noaction)
- `.github/workflows/flox-noaction-consolidated.yml` — standalone, one activation
- `.github/workflows/_checks.yml` — handle the `flox-noaction` provisioner (×10 jobs)
- `.github/workflows/experiment-driver.yml` — driver mappings for the new sides
- `init/manifest.toml` — register `flox-noaction-consolidated.yml`

Mirrors the merged flox-nocache dispatch PR. Spec/plan: `docs/superpowers/specs/2026-06-03-flox-noaction-baseline-design.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new 'flox-noaction' provisioning mode for CI workflows with Nix store caching capabilities.
  * Introduced new consolidated and suite-based test workflows that utilize the new provisioner.
  * Enhanced existing CI workflows to support the additional provisioning option, enabling more flexible testing and provisioning configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->