### PR TITLE
fix(contributors): ignore release-please bot in render

### DIFF
--- a/.contributors.yml
+++ b/.contributors.yml
@@ -17,6 +17,7 @@ ignore:
   - claude
   - github-actions[bot]
   - dependabot[bot]
+  - release-please-smorinlabs[bot]
 
 classification:
   categories:


### PR DESCRIPTION
## Problem
`main` is red: `tests/test_contributors_render.py::test_rendered_contributors_block_matches_state_and_ignore_config` fails. This blocks **every** PR (required `test` check), not just one.

## Root cause
The contributors-please #349 auto-update added `release-please-smorinlabs[bot]` to `.contributors.jsonl` (state) but it was never added to the `.contributors.yml` ignore list. The test regenerates the expected render from state-minus-ignored (7 rows) and compares to `CONTRIBUTORS.md` (6 rows) → mismatch.

## Fix
Add `release-please-smorinlabs[bot]` to the ignore list, consistent with the other automation bots already ignored (`github-actions[bot]`, `dependabot[bot]`, `Copilot`, `claude`). This drops it from the expected render → `expected == CONTRIBUTORS.md` (both 6 rows), with no change to `CONTRIBUTORS.md`.

## Verification
`uv run pytest tests/test_contributors_render.py tests/test_contributors_state.py tests/test_contributors_workflow.py` → all pass; full synced suite green.

One-line change. Unblocks the merge queue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contributor configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->