### PR TITLE
chore(ci): bump contributors-please-action @v1.0.2 → @v1.0.6

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Update contributors
-        uses: smorinlabs/contributors-please-action@v1.0.2
+        uses: smorinlabs/contributors-please-action@v1.0.6
         with:
           app-id: ${{ secrets.CONTRIBUTORS_PLEASE_APP_ID }}
           private-key: ${{ secrets.CONTRIBUTORS_PLEASE_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
Bumps the pinned version of `smorinlabs/contributors-please-action` from `@v1.0.2` to `@v1.0.6` in `.github/workflows/update-contributors.yml`.

## Background
`v1.0.2` has non-empty defaults for composable inputs (`in-place: 'false'`, `columns-per-row: '6'`, etc.) in its `action.yml`. Combined with the empty-string-check semantics in `optionalBooleanInput` / `optionalNumberInput`, those defaults silently override values set in `.contributors.yml` every run.

User-visible symptom: the bot regenerates `CONTRIBUTORS.md` as a single concatenated line with no markers — `in-place: false` (default) wins against yaml `in_place: true`, and `columns-per-row: 6` (default) wins against yaml `columns_per_row: 1`. This is the bug that produced the broken `CONTRIBUTORS.md` we just restored in #361 and (after a phantom-commit-disaster) again in #366.

`v1.0.3+` ships empty defaults for all composable inputs, with `test/outputs.test.ts` enforcing the rule. `v1.0.6` is the latest tag.

## Diff
One file, one line.

```diff
-        uses: smorinlabs/contributors-please-action@v1.0.2
+        uses: smorinlabs/contributors-please-action@v1.0.6
```

## Verification
- Tag `v1.0.6` exists on remote (`2c52e3075b...`); resolves immediately
- `test/outputs.test.ts` at HEAD of `contributors-please-action` asserts all 17 composable inputs have empty default — confirmed passing in that repo

## Out of scope
- Conflict-detection guard in the action repo (planned as PR B; defensive, not blocking this)
- Re-doing the codecov OIDC change (was PR #365 — reverted in #366 due to a phantom 'initial commit (fixture)' in the branch; needs careful redo)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build automation dependency version for improved stability and maintenance of the automated contributor management process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->