### PR TITLE
feat(ci): codecov tokenless OIDC upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+      id-token: write  # OIDC for tokenless Codecov upload (public repo)
     strategy:
       fail-fast: false  # see all failures, not just the first (round-3)
       matrix:
@@ -70,10 +71,11 @@ jobs:
         run: uv run pytest -m "" --cov=py_launch_blueprint --cov-report=xml
       - name: Upload coverage to Codecov
         # Single matrix combo uploads (avoids 4x duplicate reports).
+        # use_oidc: tokenless upload (public repo). Requires `id-token: write`.
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         uses: codecov/codecov-action@v6
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           files: coverage.xml
           flags: unittests
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
Switches the codecov-action upload to OIDC instead of `CODECOV_TOKEN`. Works for public repos without any repo secret and avoids being blocked by a deactivated/unactivated token on the Codecov side.

## Changes
- `.github/workflows/ci.yml` `test` job: add `id-token: write` permission (required for OIDC)
- codecov upload step: replace `token: ${{ secrets.CODECOV_TOKEN }}` with `use_oidc: true`

## Background
Re-do of #365 with a clean single-commit branch. The previous attempt was merged into a squash that also included a phantom `initial commit (fixture)` commit deleting 152 files; reverted in #366.

This PR was created from a fresh worktree branched off current `main` only. Post-commit verification confirmed:
- 1 commit ahead of main
- Exactly 1 file changed (`.github/workflows/ci.yml`)
- 4 lines (+3 / -1)
- Author: Steve Morin only
- Remote tip SHA matches local tip SHA

## Verification
- `.codecov.yml` already validated clean upstream (`Valid!` from `https://codecov.io/validate`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration security by updating the Codecov integration in the CI workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->