### PR TITLE
fix(dev): repair broken local lefthook hooks (commitlint, editorconfig-checker, init-tests)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,10 +9,15 @@
 min_version: 1.13.0  # ITM-021 installer floor
 
 # ITM-040 — commitlint commit-msg step. Decided round 7.
+# Use the full package name `@commitlint/cli`, not bare `commitlint`. On a cold
+# bun cache, `bunx --bun commitlint` is ambiguous (the bin and an unrelated
+# mise shim share the name), and bun falls through to PATH where the mise
+# shim wins and fails with "No version is set for shim: commitlint". Naming
+# the scoped package up-front forces bun to resolve via npm before PATH.
 commit-msg:
   commands:
     commitlint:
-      run: bunx --bun commitlint --edit {1}
+      run: bunx --bun @commitlint/cli --edit {1}
 
 # Pre-commit stage — per-tool steps land via downstream ITMs.
 pre-commit:
@@ -22,10 +27,14 @@ pre-commit:
     gitleaks:
       run: scripts/check-gitleaks.sh --staged
     # ITM-010 — editorconfig-checker staged-only (decided round 9).
+    # Use uvx (PyPI wheel bundles the Go binary) instead of the npm wrapper.
+    # The npm wrapper downloads the binary at runtime and flakes with
+    # TAR_BAD_ARCHIVE — same issue documented in .github/workflows/_checks.yml.
+    # Note: the Go binary uses single-dash flags (-config, not --config).
     editorconfig-checker:
       run: >-
-        bunx --bun editorconfig-checker
-        --config .editorconfig-checker.json
+        uvx --from editorconfig-checker ec
+        -config .editorconfig-checker.json
         {staged_files}
     # ITM-013 — yamllint staged YAML only (decided round 2).
     yamllint:
@@ -70,5 +79,18 @@ pre-push:
     # `--override-ini=addopts=` because the project default excludes
     # slow/live markers — init tests aren't marked so they need explicit
     # override to run consistently regardless of marker config drift.
+    #
+    # `env -u GIT_*` scrubs pre-push environment variables that git sets
+    # before running the hook. The init/tests fixtures spawn `git commit`
+    # in pytest tmp dirs; inherited `GIT_DIR` makes those subprocesses
+    # operate on the OUTER worktree instead of the tmp dir — which both
+    # makes tests fail (no commit happens in tmp -> guard.sh sees no repo)
+    # AND can author a "Test Fixture <test@example.com>" commit against the
+    # real blueprint repo (the 152-file-deletion class — see commit feb0938).
+    # Scrubbing the env before pytest starts covers `_git()`, `guard.sh`,
+    # and `init.py` subprocesses uniformly.
     init-tests:
-      run: uv run pytest init/tests/ --override-ini="addopts=" -q
+      run: >-
+        env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE
+        -u GIT_OBJECT_DIRECTORY -u GIT_COMMON_DIR -u GIT_PREFIX
+        uv run pytest init/tests/ --override-ini="addopts=" -q


### PR DESCRIPTION
## Summary

Three lefthook commands were intermittently blocking commits/pushes, forcing repeated `--no-verify` workarounds. All three were tool-resolution or env-leak issues hidden by warm caches and direct invocations.

- **commitlint**: `bunx --bun commitlint` is ambiguous when an unrelated `commitlint` shim sits on PATH (e.g. mise's `npm:@commitlint/cli` shim). On a cold bun cache, bun falls through to PATH and the mise shim wins, failing with `mise ERROR No version is set for shim: commitlint`. Fix: name the scoped package `@commitlint/cli` explicitly so bun resolves via npm before consulting PATH. Reproduced with `bun pm cache rm` + `lefthook run commit-msg`; passes with the fix.

- **editorconfig-checker**: the npm wrapper (v6.x) downloads the upstream Go binary at runtime, flaking with `TAR_BAD_ARCHIVE: Unrecognized archive format` — same failure already documented in `.github/workflows/_checks.yml` ("~45%: rate-limit + TAR_BAD_ARCHIVE"). Fix: switch to `uvx --from editorconfig-checker ec` (PyPI wheel bundles the binary). Note the flag dialect: the Go binary takes `-config` (single dash), not the wrapper's `--config`. Version delta 3.7.0 (npm) → 3.6.1 (PyPI). CI uses the upstream GitHub Action and is unaffected.

- **init-tests**: `git push` sets `GIT_DIR=<worktree>/.git/worktrees/<name>` in the pre-push hook env. The `init/tests/conftest.py` fixtures spawn `git init && git add -A && git commit` in pytest tmp dirs; inherited `GIT_DIR` makes those subprocesses operate on the OUTER worktree instead of the tmp dir. Tests fail (no commit lands in tmp → guard.sh sees no repo → asserts blow up). Worse: a `Test Fixture <test@example.com>` `initial commit (fixture)` commit can be authored against the real blueprint worktree — the 152-file-deletion failure class (see #366 revert). **This was reproduced once during diagnosis on this branch and reset out before push.** Fix: scrub `GIT_*` env vars before pytest starts (`env -u GIT_DIR -u GIT_WORK_TREE ...`) so every subprocess (`_git`, `guard.sh`, `init.py`) sees a clean environment.

## Test plan

- [x] `bun pm cache rm` + `lefthook run commit-msg` succeeds (cold-cache repro now passes)
- [x] `lefthook run pre-commit` runs editorconfig-checker via uvx in ~0.14s (was ~0.7s + flaky)
- [x] Real `git push` (this PR's push) ran all pre-push hooks WITHOUT `--no-verify`: gitleaks-range, init-guard-wiring, init-manifest-drift, init-path-filter, bandit, init-tests (68 passed in 3.35s) — all green
- [x] Verified no phantom `initial commit (fixture)` commit on branch

## Follow-ups (not in this PR)

- `init/tests/conftest.py` should also scrub `GIT_*` from `os.environ` at session start for hermeticity outside lefthook (e.g. CI matrices that set `GIT_DIR`). Held back to keep diff minimal and avoid colliding with the `fix/conftest-cwd-guard` branch that already edits `_git()`.
- The mise `npm:@commitlint/cli` shim is a user-machine artifact (`mise use -g npm:@commitlint/cli@21.0.2`). Not a repo concern, just the trigger that made the bunx ambiguity bite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git hook configurations to enhance development workflow.
  * Improved pre-push testing environment isolation for more reliable test execution.
  * Updated development tooling dependencies to maintain compatibility with current infrastructure standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->