### PR TITLE
docs: add adr/design/research dirs and the plbp CLI conventions spec

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# Internal engineering docs
+
+Version-controlled engineering docs that are **not** part of the published
+Sphinx site (`docs/source/`). Three buckets, by intent:
+
+| Directory | Holds | Normative? |
+|---|---|---|
+| [`adr/`](adr/) | **Architecture Decision Records** — one significant decision each, with context + consequences. | Yes (a decision) |
+| [`design/`](design/) | **Design / requirements specs** — proposals and conventions to implement. | Yes (a plan) |
+| [`research/`](research/) | **Research** — investigations, comparisons, findings. | No (exploration) |
+
+Rules of thumb:
+
+- Exploring options, benchmarking, "what's out there" → **research**.
+- Specifying what to build and how it must behave → **design**.
+- Recording a single decision (and why) so it isn't re-litigated → **ADR**.
+
+A research doc often feeds a design doc, which often crystallizes one or more
+ADRs. Cross-link them. Each subdirectory has its own `README.md` with the file
+naming + status conventions.
+
+> These docs are intentionally outside `docs/source/`, so they are reviewed in
+> PRs and kept with the code without shipping to the rendered documentation
+> site. Wire any into Sphinx later if you want them published.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,30 @@
+# Architecture Decision Records (ADRs)
+
+An ADR captures **one architecturally significant decision** — the context, the
+choice, and its consequences — so it isn't silently re-litigated later.
+
+## Conventions
+
+- **Filename:** `NNNN-kebab-title.md` (zero-padded, sequential). e.g.
+  `0001-config-file-format.md`.
+- **Status:** `Proposed` → `Accepted` → (`Superseded by NNNN` | `Deprecated`).
+- **One decision per file.** Keep it short; link to the design doc or research
+  that motivated it.
+- **Immutable once Accepted.** To change a decision, write a new ADR that
+  supersedes it (and update the old one's status), rather than editing history.
+
+Start from [`template.md`](template.md).
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| —   | _none yet_ | — |
+
+## Note on historical decisions
+
+This project references earlier decisions by short id (e.g. `ADR-01` lefthook,
+`ADR-06` uv_build, `ADR-07` trusted publishing) throughout the codebase and
+commit history. Those were recorded in the maintainer's analysis workspace
+before this directory existed. New decisions are recorded **here** going
+forward; historical ADRs can be backfilled into this format as needed.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,25 @@
+# NNNN. <short decision title>
+
+- **Status:** Proposed <!-- Proposed | Accepted | Superseded by NNNN | Deprecated -->
+- **Date:** YYYY-MM-DD
+- **Deciders:** <names / roles>
+- **Related:** <design/research docs, issues, prior ADRs>
+
+## Context
+
+What is the problem or force that requires a decision? Keep it factual — the
+constraints, the requirements, what makes this non-obvious.
+
+## Decision
+
+The choice that was made, stated plainly ("We will …").
+
+## Consequences
+
+What becomes easier or harder as a result — positive, negative, and neutral.
+Include follow-on work this decision creates.
+
+## Alternatives considered
+
+- **<Option A>** — why not.
+- **<Option B>** — why not.

--- a/docs/design/0001-plbp-cli-conventions.md
+++ b/docs/design/0001-plbp-cli-conventions.md
@@ -1,0 +1,217 @@
+# `plbp` CLI Conventions — Requirements
+
+- **Status:** Proposed
+- **Type:** Design / requirements spec
+- **Created:** 2026-06-09
+- **Applies to:** the py-launch-blueprint CLI (currently shipped as `pylb`)
+
+> **Implementation note.** This spec uses the app short name **`plbp`** and env
+> prefix **`PLBP`**, whereas the CLI merged so far ships as **`pylb`** with a
+> `PY_TOKEN` env var. Reconciling the names (rename to `plbp` / `PLBP_*`, or keep
+> `pylb` and adapt this spec) is the first thing to settle when implementing —
+> see Appendix D. The requirements below are the normative target either way.
+
+Scope: output, color, configuration (TOML), and logging conventions for the
+`py-launch-blueprint` CLI. App short name: **`plbp`**. Environment variable
+prefix: **`PLBP`**.
+
+---
+
+## 0. Terminology
+
+- **App name (namespace):** `plbp`
+- **Env prefix:** `PLBP` (every flag also resolves from `PLBP_*`)
+- **Config home:** `$XDG_CONFIG_HOME`, default `~/.config`
+- **State home:** `$XDG_STATE_HOME`, default `~/.local/state`
+
+---
+
+## 1. Framework & wiring
+
+- **R1.1** Built on Click (Typer acceptable; it is Click underneath).
+- **R1.2** Click is configured with `auto_envvar_prefix="PLBP"` so every flag
+  automatically resolves from a `PLBP_*` environment variable. Env wiring is
+  not hand-maintained.
+
+## 2. Streams
+
+- **R2.1** Program **data** is written to **stdout** only.
+- **R2.2** All **logs, diagnostics, and human messaging** are written to
+  **stderr** only.
+- **R2.3** The two streams are never mixed, so `plbp ... | jq` and similar
+  pipelines are always safe.
+
+## 3. Output format
+
+- **R3.1** `--output` / `-o` selects the **format**, not a destination.
+- **R3.2** Allowed values: `text` (default) and `json`.
+- **R3.3** Format **never** auto-switches based on TTY detection. A piped
+  invocation produces the same format as an interactive one unless `--output`
+  is given explicitly.
+- **R3.4** Default format is `text`.
+
+## 4. Output file
+
+- **R4.1** `--output-file PATH` writes program output to a file instead of
+  stdout. (Short form `-O` may be added; reserved, not required.)
+- **R4.2** `--output-file` is independent of `--output`: format is chosen by
+  `--output`, destination by `--output-file`.
+- **R4.3** Shell redirection (`plbp ... > file`) remains fully supported; the
+  flag and redirection are both valid and the user chooses.
+
+## 5. Color
+
+- **R5.1** Color auto-detects: enabled when stdout is a TTY, disabled
+  otherwise.
+- **R5.2** The universal `NO_COLOR` environment variable is honored (any
+  non-empty value disables color).
+- **R5.3** `--no-color` flag forces color off and overrides auto-detection.
+- **R5.4** Config key `color` accepts `auto` (default), `always`, `never`.
+- **R5.5** Precedence for color: `--no-color` flag > `NO_COLOR` env > config
+  `color` > auto-detect.
+
+## 6. Configuration file (TOML)
+
+- **R6.1** Config format is **TOML**, read with stdlib `tomllib` (Python 3.11+);
+  `tomli` is the fallback for older interpreters. `tomlkit` only if
+  comment-preserving writes are needed.
+- **R6.2** Config file path: `$XDG_CONFIG_HOME/plbp/plbp_config.toml`
+  (default `~/.config/plbp/plbp_config.toml`). `$XDG_CONFIG_HOME` is honored
+  when set (not hardcoded to `~/.config`).
+- **R6.3** Optional layered discovery, each layer overriding the previous:
+  1. system: `$XDG_CONFIG_DIRS/plbp/plbp_config.toml`
+  2. user: `$XDG_CONFIG_HOME/plbp/plbp_config.toml`
+  3. project-local: `./plbp_config.toml` (or `./.plbp_config.toml`)
+- **R6.4** `--config PATH` (env `PLBP_CONFIG`) overrides discovery entirely.
+- **R6.5** Config is organized into tables by concern: `[output]`, `[logging]`.
+  Keys are `snake_case`.
+
+## 7. Precedence (global)
+
+- **R7.1** Every configurable behavior resolves in this fixed order, highest
+  wins:
+
+  **CLI flag → environment variable → project config → user config →
+  system config → built-in default**
+
+## 8. Secrets
+
+- **R8.1** Secrets (e.g. tokens) are **never** stored in the TOML config file.
+- **R8.2** The token is supplied via `--token` flag or the `PLBP_TOKEN`
+  environment variable only.
+
+## 9. Logging — defaults
+
+- **R9.1** The logging subsystem is always configured; what varies is level and
+  sinks.
+- **R9.2** The **console (stderr) sink is on by default** at level `WARNING`.
+- **R9.3** The **file sink is off by default**.
+
+## 10. Logging — verbosity controls
+
+- **R10.1** `-v` raises the console level to `INFO`.
+- **R10.2** `-vv` raises the console level to `DEBUG`.
+- **R10.3** `-q` / `--quiet` lowers the console level to `ERROR`.
+- **R10.4** `--log-level {debug,info,warning,error,critical}` (env
+  `PLBP_LOG_LEVEL`) is an explicit override of the console level.
+- **R10.5** Verbosity flags affect the **console** sink only; the file sink
+  level is controlled independently (R11.4).
+
+## 11. Logging — file sink
+
+- **R11.1** The file sink is enabled by `--log-file [PATH]` (env
+  `PLBP_LOG_FILE`) or by setting `logging.file` in config.
+- **R11.2** When enabled without an explicit path, the default location is
+  `$XDG_STATE_HOME/plbp/plbp.log` (default `~/.local/state/plbp/plbp.log`).
+  Logs are treated as **state**, not config or data.
+- **R11.3** The file sink uses rotation (`RotatingFileHandler`,
+  default 10 MB × 5 backups).
+- **R11.4** The file sink has its own level (`logging.file_level`, env
+  `PLBP_LOG_FILE` companion / config), defaulting to `DEBUG`, independent of
+  the console level.
+- **R11.5** File sink format is controlled by `logging.format` (env
+  `PLBP_LOG_FORMAT`): `json` (JSONL, recommended for the file) or `text`.
+- **R11.6** Dual-sink behavior: when both sinks are active they attach to the
+  same logger; the logger floor is set to the most verbose sink, and each
+  handler filters independently — e.g. console at `WARNING`, file at `DEBUG`.
+
+## 12. Environment variables
+
+- **R12.1** All env vars are prefixed `PLBP_`. The full set:
+
+| Variable          | Controls                                   | Equivalent flag        |
+|-------------------|--------------------------------------------|------------------------|
+| `PLBP_CONFIG`     | Path to config file (overrides discovery)  | `--config`             |
+| `PLBP_OUTPUT`     | Output format (`text` \| `json`)           | `--output` / `-o`      |
+| `PLBP_COLOR`      | Color mode (`auto`\|`always`\|`never`)     | `--no-color`           |
+| `PLBP_LOG_LEVEL`  | Console log level                          | `--log-level`/`-v`/`-q`|
+| `PLBP_LOG_FILE`   | Log file path (presence enables file sink) | `--log-file`           |
+| `PLBP_LOG_FORMAT` | File sink format (`text` \| `json`)        | (config only)          |
+| `PLBP_TOKEN`      | Auth token (secret)                        | `--token`              |
+
+- **R12.2** The universal `NO_COLOR` is also honored (R5.2).
+- **R12.3** `XDG_CONFIG_HOME` and `XDG_STATE_HOME` are honored for config and
+  log-file locations respectively.
+
+---
+
+## Appendix A — Example `plbp_config.toml`
+
+```toml
+# $XDG_CONFIG_HOME/plbp/plbp_config.toml
+
+[output]
+format = "text"        # text | json        (PLBP_OUTPUT)
+color  = "auto"        # auto | always | never
+
+[logging]
+level      = "warning" # console level       (PLBP_LOG_LEVEL)
+file       = ""        # empty = off; path enables file sink (PLBP_LOG_FILE)
+file_level = "debug"   # file sink level, independent of console
+format     = "text"    # text | json (JSONL) for the file sink (PLBP_LOG_FORMAT)
+```
+
+Note: no `[auth]`/token in this file — the token is env/flag only (R8).
+
+## Appendix B — Flag summary
+
+| Flag                  | Meaning                                  | Default   |
+|-----------------------|------------------------------------------|-----------|
+| `--output` / `-o`     | Output format: `text` \| `json`          | `text`    |
+| `--output-file PATH`  | Write output to a file instead of stdout | (stdout)  |
+| `--no-color`          | Force color off                          | (auto)    |
+| `--config PATH`       | Config file override                     | (XDG)     |
+| `-v`                  | Console level → INFO                     | —         |
+| `-vv`                 | Console level → DEBUG                     | —         |
+| `-q` / `--quiet`      | Console level → ERROR                     | —         |
+| `--log-level LEVEL`   | Explicit console level                   | `warning` |
+| `--log-file [PATH]`   | Enable file sink (default XDG state path) | (off)     |
+| `--token TOKEN`       | Auth token (secret)                      | (env)     |
+
+## Appendix C — Defaults at a glance
+
+| Concern        | Default                                             |
+|----------------|-----------------------------------------------------|
+| Output format  | `text`                                              |
+| Output dest    | stdout                                              |
+| Color          | auto (TTY-detected), `NO_COLOR` honored             |
+| Config file    | `$XDG_CONFIG_HOME/plbp/plbp_config.toml`            |
+| Console logging| on, `WARNING`, to stderr                            |
+| File logging   | off                                                 |
+| File log path  | `$XDG_STATE_HOME/plbp/plbp.log` (when enabled)      |
+| File log format| JSONL recommended                                   |
+| Precedence     | flag → env → project → user → system → default      |
+
+## Appendix D — Migration notes for `py-launch-blueprint`
+
+1. Replace `.env` config with TOML; honor `$XDG_CONFIG_HOME` instead of
+   hardcoding `~/.config`.
+2. Rename the format flag usage so `--output`/`-o` is the format and
+   `--output-file` is the destination (current code uses `--format` for type
+   and `--output` for a file path — resolve before it spreads across tools).
+3. Add a real `logging` setup (currently none): console sink at `WARNING`,
+   opt-in rotating file sink under `$XDG_STATE_HOME`, dual-sink with
+   independent levels.
+4. Keep the existing stdout/stderr separation (`error_console` on stderr) — it
+   already satisfies R2.
+5. Keep the token in an env var (current `PY_TOKEN` → `PLBP_TOKEN`).

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,20 @@
+# Design / requirements specs
+
+Normative documents that specify **what to build and how it must behave** —
+feature proposals, conventions, and requirements — before or while implementing.
+
+## Conventions
+
+- **Filename:** `NNNN-kebab-title.md` (zero-padded, sequential).
+- **Status header** at the top of each doc: `Status`, `Type`, `Created`, and
+  what it `Applies to`.
+- **Status lifecycle:** `Draft` → `Proposed` → `Accepted` →
+  (`Implemented` | `Superseded` | `Withdrawn`).
+- A design doc may **spawn ADRs** for its load-bearing decisions, and may cite
+  **research** docs that motivated it. Cross-link them.
+
+## Index
+
+| Doc | Title | Status |
+|-----|-------|--------|
+| [0001](0001-plbp-cli-conventions.md) | `plbp` CLI conventions — output, color, config (TOML), logging | Proposed |

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,19 @@
+# Research
+
+Exploratory, **non-normative** documents: investigations, library/tool
+comparisons, prototypes, and findings. Research informs decisions but does not
+itself mandate anything — when a conclusion is reached, capture it in a
+[design doc](../design/) or an [ADR](../adr/).
+
+## Conventions
+
+- **Filename:** `NNNN-kebab-title.md` (sequential) or `YYYY-MM-topic.md` (dated),
+  whichever reads better for the investigation.
+- State the **question** up front and the **conclusion / recommendation** at the
+  end; link onward to any design doc or ADR it produced.
+
+## Index
+
+| Doc | Title | Date |
+|-----|-------|------|
+| —   | _none yet_ | — |

--- a/init/manifest.toml
+++ b/init/manifest.toml
@@ -212,7 +212,7 @@ files   = [
 ]
 mode    = "structured"
 
-# repo_name (text) — 164 occurrences in 23 files
+# repo_name (text) — 167 occurrences in 24 files
 [[replace]]
 field   = "repo_name"
 current = ["py-launch-blueprint"]
@@ -227,6 +227,7 @@ files   = [
   "EXAMPLECLI.md",   # 7x
   "Justfile",   # 1x
   "README.md",   # 17x
+  "docs/design/0001-plbp-cli-conventions.md",   # 3x
   "docs/source/_templates/base.html",   # 1x
   "docs/source/conf.py",   # 3x
   "docs/source/contributing/index.md",   # 1x

--- a/init/manifest.toml
+++ b/init/manifest.toml
@@ -73,7 +73,7 @@ files   = [
 ]
 mode    = "structured"
 
-# app_name (text) — 146 occurrences in 16 files
+# app_name (text) — 176 occurrences in 18 files
 # NOTE: 4-char token — safe for text mode because "plbp" was invented to be
 # substring-disjoint from real words and every other identity value.
 [[replace]]
@@ -81,6 +81,8 @@ field   = "app_name"
 current = ["plbp"]
 files   = [
   "EXAMPLECLI.md",   # 36x
+  "docs/design/0001-plbp-cli-conventions.md",   # 28x
+  "docs/design/README.md",   # 2x
   "POST_INIT.md",   # 1x
   "src/py_launch_blueprint/cli/commands/__init__.py",   # 1x
   "src/py_launch_blueprint/cli/commands/config.py",   # 9x
@@ -99,7 +101,7 @@ files   = [
 ]
 mode    = "text"
 
-# app_name_upper (text) — 80 occurrences in 11 files
+# app_name_upper (text) — 106 occurrences in 12 files
 # Derived identity (app_name.upper()): the PLBP_* env prefix and the
 # _PLBP_COMPLETE completion var. Never prompted; init derives it.
 [[replace]]
@@ -107,6 +109,7 @@ field   = "app_name_upper"
 current = ["PLBP"]
 files   = [
   "EXAMPLECLI.md",   # 12x
+  "docs/design/0001-plbp-cli-conventions.md",   # 26x
   "POST_INIT.md",   # 1x
   "src/py_launch_blueprint/cli/commands/config.py",   # 2x
   "src/py_launch_blueprint/cli/commands/projects.py",   # 1x
@@ -320,6 +323,10 @@ to   = "assets/images/logos/{package_name}_logo_150x150.png"
 [[rename]]
 from = "assets/images/logos/py_launch_blueprint_logo_100x100.png"
 to   = "assets/images/logos/{package_name}_logo_100x100.png"
+
+[[rename]]
+from = "docs/design/0001-plbp-cli-conventions.md"
+to   = "docs/design/0001-{app_name}-cli-conventions.md"
 
 [[rename]]
 from = "src/py_launch_blueprint"


### PR DESCRIPTION
## What

Creates a committed home for **internal engineering docs**, and files the `plbp` CLI conventions spec there.

```
docs/
  README.md          # explains the three buckets + when to use each
  adr/               # Architecture Decision Records (README + MADR template)
  design/            # design / requirements specs (README + index)
    0001-plbp-cli-conventions.md
  research/          # exploratory research (README)
  source/            # (unchanged) the Sphinx user-facing site
  superpowers/       # (unchanged) planning specs
```

## Why

ADRs (`ADR-01`…`ADR-08`) and design/research are referenced by id across `CLAUDE.md`, `AGENTS.md`, `RELEASE.md`, and commit history, but the `analysis/` workspace they lived in isn't in the repo and there was **no committed `docs/adr/`**. This adds that home, kept under `docs/` but **outside `docs/source/`** so these are reviewed in PRs without shipping to the rendered site.

Per our agreement: three sibling dirs (`adr` / `design` / `research`), and this doc is filed as a **design / requirements spec**.

## The spec (`docs/design/0001-plbp-cli-conventions.md`)

Added **verbatim**, with a status header and one **implementation note**: it targets app name **`plbp`** + env prefix **`PLBP_*`**, whereas the CLI merged so far ships as **`pylb`** with `PY_TOKEN`. Reconciling those names is the first decision when implementing (Appendix D). Status: **Proposed**.

## Validation
- `manifest-drift: ok` — registered the spec's 3 `py-launch-blueprint` (`repo_name`) occurrences in `init/manifest.toml` so rebrand stays complete.
- codespell + editorconfig clean.

## Next step (not in this PR)
Implementing the spec is a separate, larger change. Before that I'll need a decision on the **naming**: rename `pylb` → `plbp` (and `PY_TOKEN` → `PLBP_TOKEN`, add `auto_envvar_prefix="PLBP"`), or keep `pylb`/`PY_*` and adapt the spec. The substantive work — `--output` as *format* vs `--output-file` as *destination*, layered TOML discovery, color precedence, and a real dual-sink logging setup — follows once that's settled.

https://claude.ai/code/session_01XRniMePWXYykS8xN1Yrwbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRniMePWXYykS8xN1Yrwbr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established structured documentation framework with guidelines for Architecture Decision Records (ADRs), design specifications, and research documentation
  * Published CLI conventions specification defining output formats (text/JSON), configuration handling (TOML-based), logging behavior, color controls, and environment variable standards

* **Chores**
  * Updated project initialization templates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->