### PR TITLE
feat(cli)!: rename to plbp, layered TOML config, dotted config set (phase 1)

### DIFF
--- a/EXAMPLECLI.md
+++ b/EXAMPLECLI.md
@@ -115,10 +115,10 @@ py-projects --version
 
 ---
 
-# `pylb` — noun-verb CLI (new)
+# `plbp` — noun-verb CLI (new)
 
-`pylb` is the gh-style entry point for this project. Commands follow a
-`pylb <noun> <verb>` shape and share one set of global flags, one output
+`plbp` is the gh-style entry point for this project. Commands follow a
+`plbp <noun> <verb>` shape and share one set of global flags, one output
 contract, and structured logging out of the box. The legacy `py-projects`
 command above is preserved for back-compat.
 
@@ -140,13 +140,13 @@ human text, JSON, or Markdown.
 
 | Flag | Purpose |
 |------|---------|
-| `-o, --output [human\|json\|markdown]` | output format (default `human`) |
+| `-o, --output [text\|json\|markdown]` | output format (default `text`) |
 | `--json` | shorthand for `--output json` |
 | `-v, --verbose` | increase log verbosity (`-vv` for debug) |
 | `-q, --quiet` | suppress non-essential stderr |
 | `--no-color` | disable ANSI color |
-| `--config PATH` | path to a `.env` config file |
-| `--token TEXT` | Py token (overrides env and config file) |
+| `--config PATH` | path to a TOML config file (overrides discovery; env `PLBP_CONFIG`) |
+| `--token TEXT` | Py token (overrides `$PLBP_TOKEN`; never stored on disk) |
 | `--no-input` | never prompt; fail instead (scripts/CI) |
 | `-V, --version` | version + Python + platform (root) |
 | `-h, --help` | help at every level |
@@ -161,25 +161,27 @@ human text, JSON, or Markdown.
 
 ```bash
 # Projects (noun) → list / get (verbs)
-pylb projects list
-pylb projects list --workspace "My Workspace" --json
-pylb projects list -o markdown
-pylb projects get 12345
+plbp projects list
+plbp projects list --workspace "My Workspace" --json
+plbp projects list -o markdown
+plbp projects get 12345
 
-# Config (no network required)
-pylb config path
-pylb config get token --json
-pylb config set token <TOKEN>            # writes pylb_config.toml (0600)
-pylb config set token <TOKEN> --dry-run  # show what would change, write nothing
-pylb config set token <TOKEN> --yes      # skip the overwrite confirmation
+# Config — set/get non-secret keys by dotted path (no network required)
+plbp config path
+plbp config get output.color
+plbp config set logging.level info               # writes [logging] level
+plbp config set output.color always --dry-run    # preview, write nothing
+plbp config set logging.file_level debug --yes   # skip the overwrite prompt
+# the token is NEVER stored in config — pass --token or set $PLBP_TOKEN
+plbp config get token --json                     # masked; resolves from flag/env
 
 # Diagnose setup (Python/platform, config file, token). Exits non-zero on errors.
-pylb doctor
-pylb doctor --json
+plbp doctor
+plbp doctor --json
 
 # Shell completion
-pylb completion bash >> ~/.bashrc
-eval "$(pylb completion zsh)"
+plbp completion bash >> ~/.bashrc
+eval "$(plbp completion zsh)"
 ```
 
 Mutating commands (e.g. `config set`) share a safety pattern: `--dry-run`
@@ -189,26 +191,32 @@ prompting).
 
 ## Configuration file (TOML, XDG)
 
-`pylb` reads a TOML config file from an XDG-compliant location, namespaced
+`plbp` reads a TOML config file from an XDG-compliant location, namespaced
 under the app and named so its purpose is obvious:
 
 ```
-~/.config/pylb/pylb_config.toml          # $XDG_CONFIG_HOME/pylb/pylb_config.toml
+~/.config/plbp/plbp_config.toml          # $XDG_CONFIG_HOME/plbp/plbp_config.toml
 ```
 
 ```toml
-# pylb_config.toml
-token = "your_token_here"
-# or, equivalently:
-# [auth]
-# token = "your_token_here"
+# plbp_config.toml — non-secret settings only, organized into tables
+[output]
+format = "text"   # text | json | markdown
+color  = "auto"   # auto | always | never
+
+[logging]
+level = "warning" # console level
 ```
 
-Token precedence: `--token` > `PY_TOKEN` env var > config file. Run
-`pylb config path` to see the resolved location. The same XDG convention
-applies to other file kinds the app may create (resolved in `core/paths.py`):
-data → `$XDG_DATA_HOME/pylb/pylb_db.db`, state/logs →
-`$XDG_STATE_HOME/pylb/pylb_<name>.log`, cache → `$XDG_CACHE_HOME/pylb/`.
+Config is discovered in layers, each overriding the previous: system
+(`$XDG_CONFIG_DIRS`) → user (`$XDG_CONFIG_HOME`) → project
+(`./plbp_config.toml`); `--config` overrides discovery entirely. Per-setting
+precedence: flag → env (`PLBP_*`) → project → user → system → default.
+
+Secrets are **never** stored here — the token resolves from `--token` or
+`$PLBP_TOKEN` only. The same XDG convention applies to other file kinds
+(resolved in `core/paths.py`): data → `$XDG_DATA_HOME/plbp/plbp_db.db`,
+state/logs → `$XDG_STATE_HOME/plbp/plbp.log`, cache → `$XDG_CACHE_HOME/plbp/`.
 
 ## Structured logging
 

--- a/init/manifest.toml
+++ b/init/manifest.toml
@@ -16,7 +16,7 @@ files   = [
 ]
 mode    = "structured"
 
-# author (text) — 19 occurrences in 18 files
+# author (text) — 20 occurrences in 19 files
 [[replace]]
 field   = "author"
 current = ["Steve Morin"]
@@ -52,6 +52,7 @@ files   = [
   "src/py_launch_blueprint/core/paths.py",   # 1x
   "src/py_launch_blueprint/core/services/__init__.py",   # 1x
   "src/py_launch_blueprint/core/services/projects.py",   # 1x
+  "src/py_launch_blueprint/core/settings.py",   # 1x
   "src/py_launch_blueprint/projects.py",   # 1x
   "src/py_launch_blueprint/web/__init__.py",   # 1x
   "tests/__init__.py",   # 1x
@@ -137,7 +138,7 @@ files   = [
 ]
 mode    = "structured"
 
-# package_name (text) — 93 occurrences in 34 files
+# package_name (text) — 94 occurrences in 35 files
 [[replace]]
 field   = "package_name"
 current = ["py_launch_blueprint"]
@@ -188,6 +189,7 @@ files   = [
   "src/py_launch_blueprint/core/models.py",   # 1x
   "src/py_launch_blueprint/core/services/__init__.py",   # 1x
   "src/py_launch_blueprint/core/services/projects.py",   # 1x
+  "src/py_launch_blueprint/core/settings.py",   # 1x
   "src/py_launch_blueprint/projects.py",   # 1x
   "src/py_launch_blueprint/web/__init__.py",   # 1x
   "pyrightconfig.json",   # 1x

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,8 +90,8 @@ docs = [
 
 
 [project.scripts]
-# Noun-verb CLI (gh-style): pylb <noun> <verb>
-pylb = "py_launch_blueprint.cli.main:cli"
+# Noun-verb CLI (gh-style): plbp <noun> <verb>
+plbp = "py_launch_blueprint.cli.main:cli"
 # Back-compat: original single-command entry point (preserved).
 py-projects = "py_launch_blueprint.projects:main"
 

--- a/src/py_launch_blueprint/cli/commands/__init__.py
+++ b/src/py_launch_blueprint/cli/commands/__init__.py
@@ -17,7 +17,7 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-"""Command groups — one module per noun (gh-style: ``pylb <noun> <verb>``)."""
+"""Command groups — one module per noun (gh-style: ``plbp <noun> <verb>``)."""
 
 from py_launch_blueprint.cli.commands.config import config_group
 from py_launch_blueprint.cli.commands.projects import projects_group

--- a/src/py_launch_blueprint/cli/commands/config.py
+++ b/src/py_launch_blueprint/cli/commands/config.py
@@ -17,29 +17,33 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-"""``pylb config`` — inspect configuration (no network required).
+"""``plbp config`` — inspect and edit configuration (no network required).
 
-A second noun that exercises the same pattern without touching the API, so the
-template is clear with zero credentials.
+``config set``/``get`` operate on **dotted keys** into the config tables, e.g.
+``output.color`` or ``logging.level``. Secrets are never stored in the config
+file — the token comes from ``--token`` or ``$PLBP_TOKEN`` only.
 """
 
 import click
 
 from py_launch_blueprint.cli.context import AppContext
 from py_launch_blueprint.cli.options import confirm, global_options, mutation_options
-from py_launch_blueprint.core.config import get_default_config_path, save_token
+from py_launch_blueprint.core.config import (
+    get_default_config_path,
+    get_file_value,
+    set_config_value,
+)
 from py_launch_blueprint.core.errors import ExitCode
 from py_launch_blueprint.core.models import ConfigPath, ConfigValue
+from py_launch_blueprint.core.settings import coerce_value, parse_key, writable_keys
 
-#: Configuration keys this command knows how to surface.
-_KNOWN_KEYS = {"token"}
-#: Keys `config set` knows how to write.
-_WRITABLE_KEYS = {"token"}
+#: Keys `config get` can resolve: every settable key plus the read-only token.
+_GETTABLE_KEYS = sorted([*writable_keys(), "token"])
 
 
 @click.group(name="config")
 def config_group() -> None:
-    """Inspect CLI configuration."""
+    """Inspect and edit CLI configuration."""
 
 
 @config_group.command(name="path")
@@ -48,61 +52,77 @@ def config_path(app: AppContext) -> None:
     """Show the config file path and whether it exists.
 
     Examples:
-        pylb config path
-        pylb config path --json
+        plbp config path
+        plbp config path --json
     """
     path = app.config.config_path or get_default_config_path()
     app.renderer.render(ConfigPath(path=str(path), exists=path.exists()))
 
 
 @config_group.command(name="get")
-@click.argument("key", type=click.Choice(sorted(_KNOWN_KEYS)))
+@click.argument("key", type=click.Choice(_GETTABLE_KEYS))
 @global_options
 def config_get(app: AppContext, key: str) -> None:
-    """Show a resolved config value and which source provided it.
+    """Show a resolved config value and where it came from.
 
-    Secrets are masked. Examples:
-        pylb config get token
-        pylb config get token --json
+    The token is masked and resolves from flag/env only. Examples:
+        plbp config get output.color
+        plbp config get logging.level --json
+        plbp config get token
     """
     cfg = app.config
     if key == "token":
         value = _mask(cfg.token) if cfg.token else None
         app.renderer.render(ConfigValue(key=key, value=value, source=cfg.source))
+        return
+    section, name = parse_key(key)
+    resolved = getattr(getattr(cfg.settings, section), name)
+    app.renderer.render(ConfigValue(key=key, value=str(resolved), source="config"))
 
 
 @config_group.command(name="set")
-@click.argument("key", type=click.Choice(sorted(_WRITABLE_KEYS)))
+@click.argument("key", type=click.Choice(writable_keys()))
 @click.argument("value")
 @mutation_options
 @global_options
 def config_set(
     app: AppContext, key: str, value: str, dry_run: bool, assume_yes: bool
 ) -> None:
-    """Write a config value to the TOML config file.
+    """Write a non-secret config value to the TOML config file.
 
-    Prompts before overwriting an existing file unless --yes is given.
-    Examples:
-        pylb config set token abc123
-        pylb config set token abc123 --dry-run
-        pylb config set token abc123 --yes
+    KEY is a dotted path into the config tables. Examples:
+        plbp config set output.color always
+        plbp config set logging.level info
+        plbp config set logging.file_level debug --yes
+
+    Secrets are never stored here — supply the token via --token or
+    $PLBP_TOKEN. Prompts before overwriting an existing value unless --yes.
     """
     path = app.config.config_path or get_default_config_path()
+    section, name = parse_key(key)
+    coerced = coerce_value(section, name, value)  # validates up front
 
     if dry_run:
-        app.renderer.message(f"[dry-run] would write {key} to {path}")
-        app.renderer.render(ConfigValue(key=key, value=_mask(value), source="dry-run"))
+        app.renderer.message(f"[dry-run] would set {key} = {coerced} in {path}")
+        app.renderer.render(ConfigValue(key=key, value=str(coerced), source="dry-run"))
         return
 
-    if path.exists() and not confirm(
-        app, f"Overwrite existing config at {path}?", assume_yes=assume_yes
+    existing = get_file_value(path, key)
+    if (
+        existing is not None
+        and existing != coerced
+        and not confirm(
+            app,
+            f"Overwrite {key} ({existing} → {coerced}) in {path}?",
+            assume_yes=assume_yes,
+        )
     ):
         app.renderer.message("Aborted.")
         raise SystemExit(int(ExitCode.INTERRUPT))
 
-    save_token(path, value)
-    app.renderer.message(f"Wrote {key} to {path}")
-    app.renderer.render(ConfigValue(key=key, value=_mask(value), source="file"))
+    set_config_value(path, key, value)
+    app.renderer.message(f"Set {key} = {coerced} in {path}")
+    app.renderer.render(ConfigValue(key=key, value=str(coerced), source="file"))
 
 
 def _mask(secret: str) -> str:

--- a/src/py_launch_blueprint/cli/commands/projects.py
+++ b/src/py_launch_blueprint/cli/commands/projects.py
@@ -17,7 +17,7 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-"""``pylb projects`` — list and inspect Py projects.
+"""``plbp projects`` — list and inspect Py projects.
 
 Reference noun: shows the full best-practice shape (global flags, structured
 result → renderer, early validation, typed errors → exit codes).
@@ -42,8 +42,8 @@ def _service(app: AppContext) -> ProjectsService:
     token = app.config.token
     if not token:
         raise AuthError(
-            "No Py token found. Set PY_TOKEN, pass --token, or add it to your "
-            "config file (see `pylb config path`)."
+            "No Py token found. Supply it via --token or the $PLBP_TOKEN "
+            "environment variable (never stored in the config file)."
         )
     return ProjectsService(token)
 
@@ -62,9 +62,9 @@ def list_projects(app: AppContext, workspace: str | None, limit: int) -> None:
     """List projects, optionally filtered by workspace.
 
     Examples:
-        pylb projects list
-        pylb projects list --workspace "My Workspace" --json
-        pylb projects list -o markdown
+        plbp projects list
+        plbp projects list --workspace "My Workspace" --json
+        plbp projects list -o markdown
     """
     projects = _service(app).list_projects(workspace=workspace, limit=limit)
     app.renderer.render(ProjectList(projects=projects))
@@ -77,8 +77,8 @@ def get_project(app: AppContext, project_id: str) -> None:
     """Fetch a single project by its ID.
 
     Examples:
-        pylb projects get 12345
-        pylb projects get 12345 --json
+        plbp projects get 12345
+        plbp projects get 12345 --json
     """
     project = _service(app).get_project(project_id)
     app.renderer.render(ProjectList(projects=[project]))

--- a/src/py_launch_blueprint/cli/context.py
+++ b/src/py_launch_blueprint/cli/context.py
@@ -92,9 +92,13 @@ class AppContext:
 
 
 def _resolve_mode(output_mode: str | None, json_mode: bool) -> OutputMode:
-    """``--json`` wins; otherwise use ``--output`` or default to human."""
+    """``--json`` wins; otherwise use ``--output`` or default to text.
+
+    Format never auto-switches on TTY (R3.3): a piped run formats the same as
+    an interactive one unless ``--output`` says otherwise.
+    """
     if json_mode:
         return OutputMode.JSON
     if output_mode:
         return OutputMode(output_mode)
-    return OutputMode.HUMAN
+    return OutputMode.TEXT

--- a/src/py_launch_blueprint/cli/main.py
+++ b/src/py_launch_blueprint/cli/main.py
@@ -17,7 +17,7 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-"""Root command group for the ``pylb`` CLI.
+"""Root command group for the ``plbp`` CLI.
 
 Wires the global help option, an extended ``--version``, shell completion, and
 every noun group. Adding a noun is one import + one entry in ``COMMAND_GROUPS``
@@ -37,8 +37,8 @@ from py_launch_blueprint.cli.options import global_options
 from py_launch_blueprint.core.diagnostics import run_diagnostics
 from py_launch_blueprint.core.errors import ExitCode
 
-_COMPLETE_VAR = "_PYLB_COMPLETE"
-_PROG_NAME = "pylb"
+_COMPLETE_VAR = "_PLBP_COMPLETE"
+_PROG_NAME = "plbp"
 
 
 def _print_version(ctx: click.Context, _param: click.Parameter, value: bool) -> None:
@@ -53,7 +53,13 @@ def _print_version(ctx: click.Context, _param: click.Parameter, value: bool) -> 
 
 @click.group(
     name=_PROG_NAME,
-    context_settings={"help_option_names": ["-h", "--help"]},
+    context_settings={
+        "help_option_names": ["-h", "--help"],
+        # Every option also resolves from a PLBP_* env var (R1.2). The shared
+        # global options set explicit flat names (PLBP_OUTPUT, PLBP_CONFIG);
+        # this prefix is the catch-all for any others.
+        "auto_envvar_prefix": "PLBP",
+    },
 )
 @click.option(
     "-V",
@@ -65,10 +71,10 @@ def _print_version(ctx: click.Context, _param: click.Parameter, value: bool) -> 
     help="Show version, Python, and platform, then exit.",
 )
 def cli() -> None:
-    """pylb — a gh-style CLI for Py.
+    """plbp — a gh-style CLI for Py.
 
-    Commands follow a noun-verb shape, e.g. `pylb projects list`. Every command
-    supports -o/--output {human,json,markdown}, --json, -v/--verbose, --no-color,
+    Commands follow a noun-verb shape, e.g. `plbp projects list`. Every command
+    supports -o/--output {text,json,markdown}, --json, -v/--verbose, --no-color,
     and --config. Results go to stdout; logs and errors go to stderr.
     """
 
@@ -79,8 +85,8 @@ def completion(shell: str) -> None:
     """Print a shell completion script.
 
     Examples:
-        pylb completion bash >> ~/.bashrc
-        eval "$(pylb completion zsh)"
+        plbp completion bash >> ~/.bashrc
+        eval "$(plbp completion zsh)"
     """
     comp_cls = get_completion_class(shell)
     if comp_cls is None:  # pragma: no cover - click ships all three

--- a/src/py_launch_blueprint/cli/options.py
+++ b/src/py_launch_blueprint/cli/options.py
@@ -20,7 +20,7 @@
 """The ``@global_options`` decorator — one set of flags on every command.
 
 Stacking these per-command (rather than only on the root group) lets users put
-flags after the verb, gh-style: ``pylb projects list --json``. The decorator
+flags after the verb, gh-style: ``plbp projects list --json``. The decorator
 consumes the global values, builds an :class:`AppContext`, and passes it as the
 first argument to the wrapped command.
 """
@@ -45,7 +45,8 @@ _GLOBAL_OPTIONS: list[Callable[[Any], Any]] = [
         "output_mode",
         type=click.Choice(_OUTPUT_CHOICES),
         default=None,
-        help="Output format. [default: human]",
+        envvar="PLBP_OUTPUT",
+        help="Output format. [default: text]",
     ),
     click.option(
         "--json",
@@ -65,12 +66,13 @@ _GLOBAL_OPTIONS: list[Callable[[Any], Any]] = [
         "config_file",
         type=click.Path(dir_okay=False),
         default=None,
-        help="Path to a .env config file.",
+        envvar="PLBP_CONFIG",
+        help="Path to a TOML config file (overrides layered discovery).",
     ),
     click.option(
         "--token",
         default=None,
-        help="Py Personal Access Token (overrides env and config file).",
+        help="Py Personal Access Token (overrides $PLBP_TOKEN). Never stored.",
     ),
     click.option(
         "--no-input", is_flag=True, help="Never prompt; fail instead (for scripts/CI)."

--- a/src/py_launch_blueprint/cli/output.py
+++ b/src/py_launch_blueprint/cli/output.py
@@ -17,7 +17,7 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-"""The output contract: render any result as human / JSON / Markdown.
+"""The output contract: render any result as text / JSON / Markdown.
 
 Rules (per clig.dev):
 
@@ -41,7 +41,7 @@ from py_launch_blueprint.core.models import CLIResult
 class OutputMode(StrEnum):
     """Supported output formats. Every command honors all three."""
 
-    HUMAN = "human"
+    TEXT = "text"
     JSON = "json"
     MARKDOWN = "markdown"
 
@@ -64,9 +64,9 @@ class Renderer:
         elif self.mode is OutputMode.MARKDOWN:
             click.echo(self._to_markdown(result))
         else:
-            self._render_human(result)
+            self._render_text(result)
 
-    def _render_human(self, result: CLIResult) -> None:
+    def _render_text(self, result: CLIResult) -> None:
         columns = result.table_columns()
         if not columns or not result.table_rows():
             note = result.human_note()

--- a/src/py_launch_blueprint/core/__init__.py
+++ b/src/py_launch_blueprint/core/__init__.py
@@ -29,8 +29,9 @@ makes a single result object renderable as human text, JSON, or Markdown.
 from py_launch_blueprint.core.config import (
     Config,
     get_config_dir,
+    get_default_config_path,
     load_config,
-    save_token,
+    set_config_value,
 )
 from py_launch_blueprint.core.diagnostics import run_diagnostics
 from py_launch_blueprint.core.errors import (
@@ -49,6 +50,13 @@ from py_launch_blueprint.core.models import (
     Project,
     ProjectList,
 )
+from py_launch_blueprint.core.settings import (
+    LoggingSettings,
+    OutputSettings,
+    Settings,
+    parse_key,
+    writable_keys,
+)
 
 __all__ = [
     "APIError",
@@ -61,11 +69,17 @@ __all__ = [
     "DoctorCheck",
     "DoctorReport",
     "ExitCode",
+    "LoggingSettings",
+    "OutputSettings",
     "Project",
     "ProjectList",
     "PyError",
+    "Settings",
     "get_config_dir",
+    "get_default_config_path",
     "load_config",
+    "parse_key",
     "run_diagnostics",
-    "save_token",
+    "set_config_value",
+    "writable_keys",
 ]

--- a/src/py_launch_blueprint/core/config.py
+++ b/src/py_launch_blueprint/core/config.py
@@ -43,6 +43,7 @@ from typing import Any
 import tomli_w
 
 from py_launch_blueprint.core import paths
+from py_launch_blueprint.core.errors import ConfigError
 from py_launch_blueprint.core.settings import (
     Settings,
     coerce_value,
@@ -67,6 +68,9 @@ class Config:
     config_path: Path | None = None
     #: Config files that existed and were merged, lowest precedence first.
     loaded_paths: list[Path] = field(default_factory=list)
+    #: Non-fatal problems found while loading (invalid values dropped,
+    #: unparseable discovered layers skipped). The CLI logs these to stderr.
+    warnings: list[str] = field(default_factory=list)
 
 
 def get_config_dir() -> Path:
@@ -85,6 +89,34 @@ def _read_toml(path: Path) -> dict[str, Any]:
         return tomllib.loads(path.read_text(encoding="utf-8"))
     except (OSError, tomllib.TOMLDecodeError):
         return {}
+
+
+def _read_layer(path: Path) -> tuple[dict[str, Any], str | None]:
+    """Tolerantly read one discovered layer, reporting (data, warning)."""
+    if not path.exists():
+        return {}, None
+    try:
+        return tomllib.loads(path.read_text(encoding="utf-8")), None
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        return {}, f"ignoring unreadable config file {path}: {exc}"
+
+
+def _read_explicit(path: Path) -> dict[str, Any]:
+    """Read an explicitly named config file (``--config``/``$PLBP_CONFIG``).
+
+    A *missing* file is fine — it is a valid target for ``config set`` and
+    fresh setups. But a file that exists and cannot be parsed is a user error
+    that must not be silently ignored (R6.4: the flag overrides discovery, so
+    nothing else would supply the settings the user thinks they wrote).
+    """
+    if not path.exists():
+        return {}
+    try:
+        return tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        raise ConfigError(f"invalid TOML in config file {path}: {exc}") from exc
+    except OSError as exc:
+        raise ConfigError(f"cannot read config file {path}: {exc}") from exc
 
 
 def _discovery_paths(config_file: str | None) -> tuple[Path, list[Path]]:
@@ -109,9 +141,26 @@ def load_config(
     config_file: str | None = None,
     token_override: str | None = None,
 ) -> Config:
-    """Resolve settings (layered files) and the token (flag/env only)."""
+    """Resolve settings (layered files) and the token (flag/env only).
+
+    Tolerant by design — with one exception: an *explicit* ``--config`` file
+    that exists but cannot be parsed raises :class:`ConfigError`. Discovered
+    layers and invalid values degrade to warnings (see ``Config.warnings``).
+    """
     target, layer_paths = _discovery_paths(config_file)
-    settings = settings_from_layers([_read_toml(p) for p in layer_paths])
+
+    warnings: list[str] = []
+    layers: list[dict[str, Any]] = []
+    if config_file:
+        layers.append(_read_explicit(target))  # may raise ConfigError
+    else:
+        for p in layer_paths:
+            data, warning = _read_layer(p)
+            layers.append(data)
+            if warning:
+                warnings.append(warning)
+    settings, value_warnings = settings_from_layers(layers)
+    warnings.extend(value_warnings)
 
     token: str | None = None
     source: str | None = None
@@ -128,6 +177,7 @@ def load_config(
         settings=settings,
         config_path=target,
         loaded_paths=[p for p in layer_paths if p.exists()],
+        warnings=warnings,
     )
 
 
@@ -143,13 +193,24 @@ def get_file_value(config_path: Path, dotted_key: str) -> Any:
 def set_config_value(config_path: Path, dotted_key: str, raw_value: str) -> Any:
     """Validate + write one ``section.key`` into the TOML file, preserving rest.
 
-    Returns the coerced value. Raises :class:`ConfigError` for unknown keys or
-    invalid values (secrets are not part of the schema, so cannot be set here).
+    Returns the coerced value. Raises :class:`ConfigError` for unknown keys,
+    invalid values (secrets are not part of the schema, so cannot be set
+    here), or an existing file that cannot be parsed — never silently
+    rewrite a corrupt file, which would destroy whatever the user had in it.
     """
     section, key = parse_key(dotted_key)
     value = coerce_value(section, key, raw_value)
 
-    data = _read_toml(config_path)
+    if config_path.exists():
+        try:
+            data = tomllib.loads(config_path.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError) as exc:
+            raise ConfigError(
+                f"refusing to modify {config_path}: existing file cannot be "
+                f"parsed ({exc}). Fix or remove it first."
+            ) from exc
+    else:
+        data = {}
     table = data.get(section)
     if not isinstance(table, dict):
         table = {}
@@ -158,4 +219,7 @@ def set_config_value(config_path: Path, dotted_key: str, raw_value: str) -> Any:
 
     config_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     config_path.write_text(tomli_w.dumps(data), encoding="utf-8")
+    # Restrict to the owner: users habitually put sensitive things in CLI
+    # config files even though the schema holds no secrets.
+    config_path.chmod(0o600)
     return value

--- a/src/py_launch_blueprint/core/config.py
+++ b/src/py_launch_blueprint/core/config.py
@@ -17,123 +17,145 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-"""Configuration loading: a TOML file in an XDG-compliant location.
+"""Configuration loading: layered TOML files in XDG-compliant locations.
 
-The config file defaults to ``$XDG_CONFIG_HOME/pylb/pylb_config.toml`` (see
-``core.paths``). Its format is TOML::
+Discovery (each layer overrides the previous), per the conventions spec:
 
-    # ~/.config/pylb/pylb_config.toml
-    token = "your_token_here"
+1. system  — ``$XDG_CONFIG_DIRS/plbp/plbp_config.toml`` (default ``/etc/xdg``)
+2. user    — ``$XDG_CONFIG_HOME/plbp/plbp_config.toml`` (default ``~/.config``)
+3. project — ``./plbp_config.toml`` (or ``./.plbp_config.toml``)
 
-    # (an [auth] table is also accepted, for forward-compatibility)
-    # [auth]
-    # token = "your_token_here"
+``--config PATH`` (env ``PLBP_CONFIG``) overrides discovery entirely. Settings
+are validated against :mod:`core.settings` (the ``[output]`` / ``[logging]``
+tables).
 
-Precedence (highest wins):
-
-1. explicit override (e.g. the ``--token`` flag)
-2. environment variable (``PY_TOKEN``)
-3. the TOML config file
-
-This module only *loads* configuration; it never prints.
+Secrets are **never** stored in the config file (R8): the token resolves from
+``--token`` then ``$PLBP_TOKEN`` only — never from a file. This module only
+*loads* and *writes* configuration; it never prints.
 """
 
 import os
 import tomllib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 import tomli_w
 
 from py_launch_blueprint.core import paths
+from py_launch_blueprint.core.settings import (
+    Settings,
+    coerce_value,
+    parse_key,
+    settings_from_layers,
+)
 
-TOKEN_ENV_VAR = "PY_TOKEN"  # noqa: S105 — env var name, not a secret value
+TOKEN_ENV_VAR = "PLBP_TOKEN"  # noqa: S105 — env var name, not a secret value
 
 
 @dataclass
 class Config:
     """Resolved runtime configuration."""
 
+    #: Auth token, from ``--token`` or ``$PLBP_TOKEN`` only (never a file).
     token: str | None = None
-    #: Where the token was resolved from ("flag", "env", "file", or None).
+    #: Where the token came from ("flag", "env", or None).
     source: str | None = None
-    #: The config file path that was consulted (whether or not it existed).
+    #: Validated, layered settings (the ``[output]`` / ``[logging]`` tables).
+    settings: Settings = field(default_factory=Settings)
+    #: The writable (user, or ``--config``) config file path.
     config_path: Path | None = None
+    #: Config files that existed and were merged, lowest precedence first.
+    loaded_paths: list[Path] = field(default_factory=list)
 
 
 def get_config_dir() -> Path:
-    """Return the per-user config directory (``$XDG_CONFIG_HOME/pylb``)."""
+    """Return the per-user config directory (``$XDG_CONFIG_HOME/plbp``)."""
     return paths.config_dir()
 
 
 def get_default_config_path() -> Path:
-    """Return the default TOML config file path (``…/pylb/pylb_config.toml``)."""
+    """Return the default (user) TOML config path (``…/plbp/plbp_config.toml``)."""
     return paths.config_file()
 
 
-def _read_toml_token(path: Path) -> str | None:
-    """Extract a token from a TOML config file (top-level or ``[auth]``)."""
+def _read_toml(path: Path) -> dict[str, Any]:
+    """Parse a TOML file to a dict; missing/invalid files read as empty."""
     try:
-        data = tomllib.loads(path.read_text(encoding="utf-8"))
+        return tomllib.loads(path.read_text(encoding="utf-8"))
     except (OSError, tomllib.TOMLDecodeError):
-        return None
-    token = data.get("token")
-    if token is None and isinstance(data.get("auth"), dict):
-        token = data["auth"].get("token")
-    return token if isinstance(token, str) else None
+        return {}
+
+
+def _discovery_paths(config_file: str | None) -> tuple[Path, list[Path]]:
+    """Return ``(write_target, layer_paths)`` lowest precedence first.
+
+    ``--config`` collapses discovery to that single file; otherwise the
+    system → user → project layers apply.
+    """
+    if config_file:
+        target = Path(config_file)
+        return target, [target]
+    target = paths.config_file()
+    layers = [
+        *reversed(paths.system_config_files()),  # system (lowest first)
+        target,  # user
+        paths.project_config_file(),  # project (highest)
+    ]
+    return target, layers
 
 
 def load_config(
     config_file: str | None = None,
     token_override: str | None = None,
 ) -> Config:
-    """Resolve configuration from flag, environment, then the TOML file.
+    """Resolve settings (layered files) and the token (flag/env only)."""
+    target, layer_paths = _discovery_paths(config_file)
+    settings = settings_from_layers([_read_toml(p) for p in layer_paths])
 
-    Args:
-        config_file: Optional explicit path to a TOML config file. Falls back
-            to the default XDG location when omitted.
-        token_override: Optional token supplied directly (e.g. ``--token``),
-            taking precedence over all other sources.
-
-    Returns:
-        A :class:`Config`. ``token`` may be ``None`` if nothing provided one;
-        callers that require a token should raise ``AuthError`` themselves.
-    """
-    config_path = Path(config_file) if config_file else get_default_config_path()
-
-    # 1. explicit override
+    token: str | None = None
+    source: str | None = None
     if token_override:
-        return Config(token=token_override, source="flag", config_path=config_path)
+        token, source = token_override, "flag"
+    else:
+        env_token = os.getenv(TOKEN_ENV_VAR)
+        if env_token:
+            token, source = env_token, "env"
 
-    # 2. environment variable
-    env_token = os.getenv(TOKEN_ENV_VAR)
-    if env_token:
-        return Config(token=env_token, source="env", config_path=config_path)
-
-    # 3. TOML config file (only if present; missing file is not an error here)
-    if config_path.exists():
-        file_token = _read_toml_token(config_path)
-        if file_token:
-            return Config(token=file_token, source="file", config_path=config_path)
-
-    return Config(token=None, source=None, config_path=config_path)
+    return Config(
+        token=token,
+        source=source,
+        settings=settings,
+        config_path=target,
+        loaded_paths=[p for p in layer_paths if p.exists()],
+    )
 
 
-def save_token(config_path: Path, token: str) -> Path:
-    """Write ``token`` into the TOML config file, preserving other keys.
+def get_file_value(config_path: Path, dotted_key: str) -> Any:
+    """Return the value of ``section.key`` as stored in ``config_path``, or None."""
+    section, key = parse_key(dotted_key)
+    table = _read_toml(config_path).get(section)
+    if isinstance(table, dict) and key in table:
+        return table[key]
+    return None
 
-    Creates the parent directory (0700) and restricts the file to 0600 — it
-    holds a secret. Returns the path written.
+
+def set_config_value(config_path: Path, dotted_key: str, raw_value: str) -> Any:
+    """Validate + write one ``section.key`` into the TOML file, preserving rest.
+
+    Returns the coerced value. Raises :class:`ConfigError` for unknown keys or
+    invalid values (secrets are not part of the schema, so cannot be set here).
     """
-    data: dict[str, Any] = {}
-    if config_path.exists():
-        try:
-            data = dict(tomllib.loads(config_path.read_text(encoding="utf-8")))
-        except tomllib.TOMLDecodeError:
-            data = {}
-    data["token"] = token
+    section, key = parse_key(dotted_key)
+    value = coerce_value(section, key, raw_value)
+
+    data = _read_toml(config_path)
+    table = data.get(section)
+    if not isinstance(table, dict):
+        table = {}
+    table[key] = value
+    data[section] = table
+
     config_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     config_path.write_text(tomli_w.dumps(data), encoding="utf-8")
-    config_path.chmod(0o600)
-    return config_path
+    return value

--- a/src/py_launch_blueprint/core/config.py
+++ b/src/py_launch_blueprint/core/config.py
@@ -69,7 +69,7 @@ class Config:
     #: Config files that existed and were merged, lowest precedence first.
     loaded_paths: list[Path] = field(default_factory=list)
     #: Non-fatal problems found while loading (invalid values dropped,
-    #: unparseable discovered layers skipped). The CLI logs these to stderr.
+    #: unparsable discovered layers skipped). The CLI logs these to stderr.
     warnings: list[str] = field(default_factory=list)
 
 

--- a/src/py_launch_blueprint/core/diagnostics.py
+++ b/src/py_launch_blueprint/core/diagnostics.py
@@ -17,7 +17,7 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-"""Environment/setup diagnostics for `pylb doctor`.
+"""Environment/setup diagnostics for `plbp doctor`.
 
 Pure logic: takes a resolved :class:`Config` and inspects the runtime, never
 printing. The CLI renders the returned :class:`DoctorReport`.
@@ -72,8 +72,8 @@ def run_diagnostics(config: Config) -> DoctorReport:
                 name="token",
                 status="warn",
                 detail=(
-                    f"not set (use --token, ${TOKEN_ENV_VAR}, "
-                    "or `pylb config set token`)"
+                    f"not set (supply via --token or ${TOKEN_ENV_VAR}; "
+                    "never stored in config)"
                 ),
             )
         )

--- a/src/py_launch_blueprint/core/models.py
+++ b/src/py_launch_blueprint/core/models.py
@@ -120,7 +120,7 @@ class DoctorCheck(BaseModel):
 
 
 class DoctorReport(CLIResult):
-    """Aggregated diagnostics for `pylb doctor`."""
+    """Aggregated diagnostics for `plbp doctor`."""
 
     checks: list[DoctorCheck]
 

--- a/src/py_launch_blueprint/core/paths.py
+++ b/src/py_launch_blueprint/core/paths.py
@@ -27,14 +27,14 @@ Follows the `XDG Base Directory Specification
 * ``$XDG_STATE_HOME``  (default ``~/.local/state``) — logs/history (recoverable)
 * ``$XDG_CACHE_HOME``  (default ``~/.cache``)       — regenerable cache
 
-Everything is namespaced under one per-app directory (``<XDG>/pylb/``), and
+Everything is namespaced under one per-app directory (``<XDG>/plbp/``), and
 files are named ``<app>_<kind>.<ext>`` so a stray file on disk announces both
 its owner and its purpose:
 
-    ~/.config/pylb/pylb_config.toml
-    ~/.local/share/pylb/pylb_db.db
-    ~/.local/state/pylb/pylb_history.log
-    ~/.cache/pylb/
+    ~/.config/plbp/plbp_config.toml
+    ~/.local/share/plbp/plbp_db.db
+    ~/.local/state/plbp/plbp.log
+    ~/.cache/plbp/
 
 Spec edge cases handled: an XDG variable that is unset, empty, or holds a
 *relative* path is ignored in favor of the default (the spec mandates absolute
@@ -45,7 +45,7 @@ import os
 from pathlib import Path
 
 #: The CLI/binary name — also the XDG namespace and the filename prefix.
-APP_NAME = "pylb"
+APP_NAME = "plbp"
 
 
 def _xdg_base(env_var: str, default: Path) -> Path:
@@ -67,6 +67,17 @@ def _home() -> Path:
 
 def config_home() -> Path:
     return _xdg_base("XDG_CONFIG_HOME", _home() / ".config")
+
+
+def config_dirs() -> list[Path]:
+    """System config dirs from ``$XDG_CONFIG_DIRS`` (default ``/etc/xdg``).
+
+    Returned highest-precedence first, matching the spec (earlier entries in
+    ``XDG_CONFIG_DIRS`` win). Empty/relative entries are ignored.
+    """
+    raw = os.environ.get("XDG_CONFIG_DIRS", "")
+    dirs = [Path(p) for p in raw.split(os.pathsep) if p and Path(p).is_absolute()]
+    return dirs or [Path("/etc/xdg")]
 
 
 def data_home() -> Path:
@@ -103,18 +114,41 @@ def cache_dir() -> Path:
 # -- intent-revealing filenames: <app>_<kind>.<ext> -----------------------
 
 
+CONFIG_FILENAME = f"{APP_NAME}_config.toml"
+
+
 def config_file() -> Path:
-    """Default config file: ``<config>/pylb/pylb_config.toml``."""
-    return config_dir() / f"{APP_NAME}_config.toml"
+    """Default (user) config file: ``<config>/plbp/plbp_config.toml``."""
+    return config_dir() / CONFIG_FILENAME
+
+
+def system_config_files() -> list[Path]:
+    """System config files, lowest-precedence layer (``<dir>/plbp/...``)."""
+    return [d / APP_NAME / CONFIG_FILENAME for d in config_dirs()]
+
+
+def project_config_file(start: Path | None = None) -> Path:
+    """Project-local config file in ``start`` (cwd): ``./plbp_config.toml``.
+
+    The dotfile form ``./.plbp_config.toml`` is preferred when it exists.
+    """
+    base = start or Path.cwd()
+    dotfile = base / f".{CONFIG_FILENAME}"
+    return dotfile if dotfile.exists() else base / CONFIG_FILENAME
+
+
+def log_file() -> Path:
+    """Default log file (state): ``<state>/plbp/plbp.log``."""
+    return state_dir() / f"{APP_NAME}.log"
 
 
 def database_file(name: str = "db", ext: str = "db") -> Path:
-    """Default database file: ``<data>/pylb/pylb_db.db``."""
+    """Default database file: ``<data>/plbp/plbp_db.db``."""
     return data_dir() / f"{APP_NAME}_{name}.{ext}"
 
 
 def state_file(name: str, ext: str = "log") -> Path:
-    """A state file (logs/history): ``<state>/pylb/pylb_<name>.<ext>``."""
+    """A state file (logs/history): ``<state>/plbp/plbp_<name>.<ext>``."""
     return state_dir() / f"{APP_NAME}_{name}.{ext}"
 
 

--- a/src/py_launch_blueprint/core/settings.py
+++ b/src/py_launch_blueprint/core/settings.py
@@ -123,12 +123,42 @@ def _allowed_hint(model: type[BaseModel], key: str) -> str | None:
     return None
 
 
-def settings_from_layers(layers: list[dict[str, Any]]) -> Settings:
-    """Merge config dicts (lowest precedence first) and validate into Settings."""
+def settings_from_layers(
+    layers: list[dict[str, Any]],
+) -> tuple[Settings, list[str]]:
+    """Merge config dicts (lowest precedence first) and validate into Settings.
+
+    Invalid values are **dropped with a warning** rather than raised: config
+    must never brick the CLI — the user needs ``config set``/``config path``
+    working in order to repair the file. Returns ``(settings, warnings)``.
+    """
     merged: dict[str, dict[str, Any]] = {}
     for layer in layers:
         for section in _SECTIONS:
             table = layer.get(section)
             if isinstance(table, dict):
                 merged.setdefault(section, {}).update(table)
-    return Settings.model_validate(merged)
+
+    warnings: list[str] = []
+    try:
+        return Settings.model_validate(merged), warnings
+    except ValidationError as exc:
+        for err in exc.errors():
+            loc = err["loc"][:2]
+            if len(loc) == 2 and loc[0] in merged:
+                section, key = str(loc[0]), str(loc[1])
+                bad = merged[section].pop(key, None)
+                hint = (
+                    _allowed_hint(_SECTIONS[section], key)
+                    if (key in _SECTIONS[section].model_fields)
+                    else None
+                )
+                suffix = f" (allowed: {hint})" if hint else ""
+                warnings.append(
+                    f"ignoring invalid config value {section}.{key} = {bad!r}{suffix}"
+                )
+    try:
+        return Settings.model_validate(merged), warnings
+    except ValidationError:  # pragma: no cover — defensive double-fault
+        warnings.append("config could not be validated; using built-in defaults")
+        return Settings(), warnings

--- a/src/py_launch_blueprint/core/settings.py
+++ b/src/py_launch_blueprint/core/settings.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2025, Steve Morin
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""Typed configuration schema for the TOML config file.
+
+Config is organized into tables by concern — ``[output]`` and ``[logging]`` —
+with ``snake_case`` keys. This module is the single source of truth for that
+schema: the loader validates files against it, and ``config set``/``config
+get`` operate on **dotted keys** (e.g. ``logging.level``) resolved against it.
+
+Secrets are deliberately *not* part of this schema — the token is supplied via
+``--token`` or ``$PLBP_TOKEN`` only, never written to the config file.
+"""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ValidationError
+
+from py_launch_blueprint.core.errors import ConfigError
+
+_Level = Literal["debug", "info", "warning", "error", "critical"]
+
+
+class OutputSettings(BaseModel):
+    """The ``[output]`` table."""
+
+    model_config = {"extra": "ignore"}
+
+    format: Literal["text", "json", "markdown"] = "text"
+    color: Literal["auto", "always", "never"] = "auto"
+
+
+class LoggingSettings(BaseModel):
+    """The ``[logging]`` table."""
+
+    model_config = {"extra": "ignore"}
+
+    level: _Level = "warning"
+    file: str = ""
+    file_level: _Level = "debug"
+    format: Literal["text", "json"] = "text"
+
+
+class Settings(BaseModel):
+    """Resolved, validated config (defaults applied for anything unset)."""
+
+    model_config = {"extra": "ignore"}
+
+    output: OutputSettings = OutputSettings()
+    logging: LoggingSettings = LoggingSettings()
+
+
+#: section name -> submodel, the only tables `config set`/`get` accept.
+_SECTIONS: dict[str, type[BaseModel]] = {
+    "output": OutputSettings,
+    "logging": LoggingSettings,
+}
+
+
+def writable_keys() -> list[str]:
+    """All settable dotted keys, e.g. ``["logging.level", "output.color", …]``."""
+    return sorted(
+        f"{section}.{name}"
+        for section, model in _SECTIONS.items()
+        for name in model.model_fields
+    )
+
+
+def parse_key(dotted: str) -> tuple[str, str]:
+    """Split ``"logging.level"`` into ``("logging", "level")``, validating both.
+
+    Raises :class:`ConfigError` for an unknown section or key (never a secret).
+    """
+    parts = dotted.split(".")
+    if len(parts) != 2 or parts[0] not in _SECTIONS:
+        raise ConfigError(
+            f"unknown config key {dotted!r}. "
+            f"Settable keys: {', '.join(writable_keys())}"
+        )
+    section, key = parts
+    if key not in _SECTIONS[section].model_fields:
+        raise ConfigError(
+            f"unknown config key {dotted!r}. "
+            f"Settable keys: {', '.join(writable_keys())}"
+        )
+    return section, key
+
+
+def coerce_value(section: str, key: str, raw: str) -> Any:
+    """Validate + coerce a raw string against the field's type/allowed values."""
+    model = _SECTIONS[section]
+    try:
+        validated = model.model_validate({key: raw})
+    except ValidationError as exc:
+        allowed = _allowed_hint(model, key)
+        hint = f" (allowed: {allowed})" if allowed else ""
+        raise ConfigError(f"invalid value for {section}.{key}: {raw!r}{hint}") from exc
+    return getattr(validated, key)
+
+
+def _allowed_hint(model: type[BaseModel], key: str) -> str | None:
+    """Render the allowed values for a Literal field, for error messages."""
+    annotation = model.model_fields[key].annotation
+    choices = getattr(annotation, "__args__", None)
+    if choices and all(isinstance(c, str) for c in choices):
+        return ", ".join(choices)
+    return None
+
+
+def settings_from_layers(layers: list[dict[str, Any]]) -> Settings:
+    """Merge config dicts (lowest precedence first) and validate into Settings."""
+    merged: dict[str, dict[str, Any]] = {}
+    for layer in layers:
+        for section in _SECTIONS:
+            table = layer.get(section)
+            if isinstance(table, dict):
+                merged.setdefault(section, {}).update(table)
+    return Settings.model_validate(merged)

--- a/tests/cli/test_pylb.py
+++ b/tests/cli/test_pylb.py
@@ -251,3 +251,32 @@ def test_config_set_env_var_resolution(runner, tmp_path, monkeypatch):
     # PLBP_OUTPUT=json → output is parseable JSON without passing --json.
     payload = json.loads(result.output)
     assert payload["value"] == "info"
+
+
+# -- config robustness (review findings) -----------------------------------
+
+
+def test_invalid_config_value_does_not_crash_commands(runner, tmp_path, monkeypatch):
+    monkeypatch.delenv("PLBP_TOKEN", raising=False)
+    cfg = tmp_path / "plbp_config.toml"
+    cfg.write_text('[output]\ncolor = "yes"\n')  # invalid value
+    result = runner.invoke(cli, ["config", "path", "--config", str(cfg)])
+    assert result.exit_code == 0  # command works on defaults
+    # ...and config set can still repair the bad value:
+    result = runner.invoke(
+        cli, ["config", "set", "output.color", "auto", "--config", str(cfg), "--yes"]
+    )
+    assert result.exit_code == 0
+    assert 'color = "auto"' in cfg.read_text()
+
+
+def test_config_set_refuses_corrupt_file(runner, tmp_path, monkeypatch):
+    monkeypatch.delenv("PLBP_TOKEN", raising=False)
+    cfg = tmp_path / "plbp_config.toml"
+    cfg.write_text('[output\ncolor = "always"\n')  # TOML syntax error
+    before = cfg.read_text()
+    result = runner.invoke(
+        cli, ["config", "set", "logging.level", "info", "--config", str(cfg)]
+    )
+    assert result.exit_code != 0
+    assert cfg.read_text() == before  # nothing destroyed

--- a/tests/cli/test_pylb.py
+++ b/tests/cli/test_pylb.py
@@ -1,4 +1,4 @@
-"""Tests for the new noun-verb `pylb` CLI (via Click's CliRunner)."""
+"""Tests for the new noun-verb `plbp` CLI (via Click's CliRunner)."""
 
 import json
 from unittest.mock import Mock, patch
@@ -37,7 +37,7 @@ def test_help_lists_nouns(runner):
 def test_completion_bash(runner):
     result = runner.invoke(cli, ["completion", "bash"])
     assert result.exit_code == 0
-    assert "_PYLB_COMPLETE" in result.output
+    assert "_PLBP_COMPLETE" in result.output
 
 
 # -- projects noun --------------------------------------------------------
@@ -94,14 +94,14 @@ def test_projects_get(runner, mock_service):
 
 
 def test_projects_no_token_auth_error(runner, monkeypatch):
-    monkeypatch.delenv("PY_TOKEN", raising=False)
+    monkeypatch.delenv("PLBP_TOKEN", raising=False)
     result = runner.invoke(cli, ["projects", "list", "--config", "/nope/.env"])
     assert result.exit_code == 2  # ExitCode.AUTH
     assert "No Py token" in result.output
 
 
 def test_projects_no_token_auth_error_json(runner, monkeypatch):
-    monkeypatch.delenv("PY_TOKEN", raising=False)
+    monkeypatch.delenv("PLBP_TOKEN", raising=False)
     result = runner.invoke(
         cli, ["projects", "list", "--config", "/nope/.env", "--json"]
     )
@@ -115,7 +115,7 @@ def test_projects_no_token_auth_error_json(runner, monkeypatch):
 
 
 def test_config_path(runner, monkeypatch):
-    monkeypatch.delenv("PY_TOKEN", raising=False)
+    monkeypatch.delenv("PLBP_TOKEN", raising=False)
     result = runner.invoke(cli, ["config", "path", "--config", "/nope/.env", "--json"])
     assert result.exit_code == 0
     payload = json.loads(result.output)
@@ -137,17 +137,17 @@ def test_config_get_token_masked(runner):
 
 
 def test_doctor_human(runner, monkeypatch):
-    monkeypatch.delenv("PY_TOKEN", raising=False)
-    result = runner.invoke(cli, ["doctor", "--config", "/nope/pylb_config.toml"])
+    monkeypatch.delenv("PLBP_TOKEN", raising=False)
+    result = runner.invoke(cli, ["doctor", "--config", "/nope/plbp_config.toml"])
     assert result.exit_code == 0  # missing token is a warn, not an error
     assert "python" in result.output
     assert "config-file" in result.output
 
 
 def test_doctor_json(runner, monkeypatch):
-    monkeypatch.delenv("PY_TOKEN", raising=False)
+    monkeypatch.delenv("PLBP_TOKEN", raising=False)
     result = runner.invoke(
-        cli, ["doctor", "--config", "/nope/pylb_config.toml", "--json"]
+        cli, ["doctor", "--config", "/nope/plbp_config.toml", "--json"]
     )
     assert result.exit_code == 0
     payload = json.loads(result.output)
@@ -155,48 +155,99 @@ def test_doctor_json(runner, monkeypatch):
     assert {"python", "platform", "config-file", "token"} <= names
 
 
-# -- config set (mutating: dry-run + confirmation) ------------------------
-
-
-def test_config_set_writes_toml(runner, tmp_path, monkeypatch):
-    monkeypatch.delenv("PY_TOKEN", raising=False)
-    cfg = tmp_path / "pylb_config.toml"
+def test_config_get_setting(runner, tmp_path, monkeypatch):
+    monkeypatch.delenv("PLBP_TOKEN", raising=False)
+    cfg = tmp_path / "plbp_config.toml"
+    cfg.write_text('[output]\ncolor = "always"\n')
     result = runner.invoke(
-        cli, ["config", "set", "token", "secrettoken", "--config", str(cfg)]
+        cli, ["config", "get", "output.color", "--config", str(cfg), "--json"]
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["value"] == "always"
+
+
+# -- config set (nested keys; mutating: dry-run + confirmation) -----------
+
+
+def test_config_set_writes_nested_table(runner, tmp_path, monkeypatch):
+    monkeypatch.delenv("PLBP_TOKEN", raising=False)
+    cfg = tmp_path / "plbp_config.toml"
+    result = runner.invoke(
+        cli, ["config", "set", "logging.level", "info", "--config", str(cfg)]
     )
     assert result.exit_code == 0
     assert cfg.exists()
-    assert 'token = "secrettoken"' in cfg.read_text()
-    assert "secrettoken" not in result.output  # value is masked in output
+    body = cfg.read_text()
+    assert "[logging]" in body
+    assert 'level = "info"' in body
+
+
+def test_config_set_rejects_token_key(runner, tmp_path, monkeypatch):
+    monkeypatch.delenv("PLBP_TOKEN", raising=False)
+    cfg = tmp_path / "plbp_config.toml"
+    result = runner.invoke(
+        cli, ["config", "set", "token", "secret", "--config", str(cfg)]
+    )
+    assert result.exit_code != 0  # secrets are not settable keys
+    assert not cfg.exists()
+
+
+def test_config_set_rejects_invalid_value(runner, tmp_path, monkeypatch):
+    monkeypatch.delenv("PLBP_TOKEN", raising=False)
+    cfg = tmp_path / "plbp_config.toml"
+    result = runner.invoke(
+        cli, ["config", "set", "output.color", "rainbow", "--config", str(cfg)]
+    )
+    assert result.exit_code != 0
+    assert not cfg.exists()
 
 
 def test_config_set_dry_run_writes_nothing(runner, tmp_path, monkeypatch):
-    monkeypatch.delenv("PY_TOKEN", raising=False)
-    cfg = tmp_path / "pylb_config.toml"
+    monkeypatch.delenv("PLBP_TOKEN", raising=False)
+    cfg = tmp_path / "plbp_config.toml"
     result = runner.invoke(
-        cli, ["config", "set", "token", "x", "--config", str(cfg), "--dry-run"]
+        cli,
+        ["config", "set", "output.color", "never", "--config", str(cfg), "--dry-run"],
     )
     assert result.exit_code == 0
     assert not cfg.exists()
 
 
 def test_config_set_overwrite_refused_with_no_input(runner, tmp_path, monkeypatch):
-    monkeypatch.delenv("PY_TOKEN", raising=False)
-    cfg = tmp_path / "pylb_config.toml"
-    cfg.write_text('token = "old"\n')
+    monkeypatch.delenv("PLBP_TOKEN", raising=False)
+    cfg = tmp_path / "plbp_config.toml"
+    cfg.write_text('[logging]\nlevel = "warning"\n')
     result = runner.invoke(
-        cli, ["config", "set", "token", "new", "--config", str(cfg), "--no-input"]
+        cli,
+        ["config", "set", "logging.level", "info", "--config", str(cfg), "--no-input"],
     )
-    assert result.exit_code == 1  # ExitCode.CONFIG — refused without --yes
-    assert cfg.read_text() == 'token = "old"\n'  # unchanged
+    assert result.exit_code == 1  # refused: overwriting an existing value
+    assert 'level = "warning"' in cfg.read_text()  # unchanged
 
 
 def test_config_set_overwrite_with_yes(runner, tmp_path, monkeypatch):
-    monkeypatch.delenv("PY_TOKEN", raising=False)
-    cfg = tmp_path / "pylb_config.toml"
-    cfg.write_text('token = "old"\n')
+    monkeypatch.delenv("PLBP_TOKEN", raising=False)
+    cfg = tmp_path / "plbp_config.toml"
+    cfg.write_text('[logging]\nlevel = "warning"\n')
     result = runner.invoke(
-        cli, ["config", "set", "token", "newtoken", "--config", str(cfg), "--yes"]
+        cli,
+        ["config", "set", "logging.level", "info", "--config", str(cfg), "--yes"],
     )
     assert result.exit_code == 0
-    assert 'token = "newtoken"' in cfg.read_text()
+    assert 'level = "info"' in cfg.read_text()
+
+
+def test_config_set_env_var_resolution(runner, tmp_path, monkeypatch):
+    # PLBP_OUTPUT resolves the --output format (R12); --json still overrides.
+    monkeypatch.setenv("PLBP_OUTPUT", "json")
+    monkeypatch.delenv("PLBP_TOKEN", raising=False)
+    cfg = tmp_path / "plbp_config.toml"
+    cfg.write_text('[logging]\nlevel = "info"\n')
+    result = runner.invoke(
+        cli, ["config", "get", "logging.level", "--config", str(cfg)]
+    )
+    assert result.exit_code == 0
+    # PLBP_OUTPUT=json → output is parseable JSON without passing --json.
+    payload = json.loads(result.output)
+    assert payload["value"] == "info"

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -180,7 +180,7 @@ def test_invalid_value_warns_and_defaults(tmp_path, monkeypatch):
 
 
 def test_explicit_config_invalid_toml_raises(tmp_path, monkeypatch):
-    # --config naming an unparseable file is a loud user error (not ignored).
+    # --config naming an unparsable file is a loud user error (not ignored).
     monkeypatch.delenv(TOKEN_ENV_VAR, raising=False)
     cfg_file = tmp_path / "plbp_config.toml"
     cfg_file.write_text('[output\ncolor = "always"\n')  # unclosed table

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -3,6 +3,8 @@
 import logging
 from pathlib import Path
 
+import pytest
+
 from py_launch_blueprint.core import (
     Config,
     ConfigPath,
@@ -11,8 +13,14 @@ from py_launch_blueprint.core import (
     load_config,
     paths,
 )
-from py_launch_blueprint.core.config import TOKEN_ENV_VAR
+from py_launch_blueprint.core.config import (
+    TOKEN_ENV_VAR,
+    get_file_value,
+    set_config_value,
+)
+from py_launch_blueprint.core.errors import ConfigError
 from py_launch_blueprint.core.logging import LogFormat, configure_logging, get_logger
+from py_launch_blueprint.core.settings import writable_keys
 
 
 def test_project_list_renders_rows():
@@ -52,38 +60,73 @@ def test_load_config_flag_wins(monkeypatch):
     assert cfg.source == "flag"
 
 
-def test_load_config_env_over_file(tmp_path, monkeypatch):
-    cfg_file = tmp_path / "pylb_config.toml"
-    cfg_file.write_text('token = "file_token"\n')
-    monkeypatch.setenv(TOKEN_ENV_VAR, "env_token")
-    cfg = load_config(config_file=str(cfg_file))
-    assert cfg.token == "env_token"
-    assert cfg.source == "env"
-
-
-def test_load_config_file_fallback_toml(tmp_path, monkeypatch):
-    cfg_file = tmp_path / "pylb_config.toml"
+def test_token_never_read_from_file(tmp_path, monkeypatch):
+    # R8: a token in the config file is ignored — secrets are flag/env only.
+    cfg_file = tmp_path / "plbp_config.toml"
     cfg_file.write_text('token = "file_token"\n')
     monkeypatch.delenv(TOKEN_ENV_VAR, raising=False)
     cfg = load_config(config_file=str(cfg_file))
-    assert cfg.token == "file_token"
-    assert cfg.source == "file"
-
-
-def test_load_config_file_fallback_auth_table(tmp_path, monkeypatch):
-    cfg_file = tmp_path / "pylb_config.toml"
-    cfg_file.write_text('[auth]\ntoken = "table_token"\n')
-    monkeypatch.delenv(TOKEN_ENV_VAR, raising=False)
-    cfg = load_config(config_file=str(cfg_file))
-    assert cfg.token == "table_token"
+    assert cfg.token is None
+    assert cfg.source is None
 
 
 def test_load_config_missing(monkeypatch):
     monkeypatch.delenv(TOKEN_ENV_VAR, raising=False)
-    cfg = load_config(config_file="/nonexistent/path/.env")
+    cfg = load_config(config_file="/nonexistent/path/plbp_config.toml")
     assert isinstance(cfg, Config)
     assert cfg.token is None
     assert cfg.source is None
+
+
+def test_settings_parsed_from_file(tmp_path, monkeypatch):
+    monkeypatch.delenv(TOKEN_ENV_VAR, raising=False)
+    cfg_file = tmp_path / "plbp_config.toml"
+    cfg_file.write_text('[output]\ncolor = "always"\n[logging]\nlevel = "info"\n')
+    cfg = load_config(config_file=str(cfg_file))
+    assert cfg.settings.output.color == "always"
+    assert cfg.settings.logging.level == "info"
+    assert cfg.settings.output.format == "text"  # default for unset keys
+
+
+def test_settings_defaults_when_no_file(monkeypatch):
+    monkeypatch.delenv(TOKEN_ENV_VAR, raising=False)
+    cfg = load_config(config_file="/nonexistent/plbp_config.toml")
+    assert cfg.settings.output.format == "text"
+    assert cfg.settings.output.color == "auto"
+    assert cfg.settings.logging.level == "warning"
+
+
+def test_set_config_value_writes_nested_table(tmp_path):
+    cfg_file = tmp_path / "plbp_config.toml"
+    set_config_value(cfg_file, "logging.level", "info")
+    set_config_value(cfg_file, "output.color", "always")
+    assert get_file_value(cfg_file, "logging.level") == "info"
+    assert get_file_value(cfg_file, "output.color") == "always"
+    # Re-loading reflects the written values.
+    cfg = load_config(config_file=str(cfg_file))
+    assert cfg.settings.logging.level == "info"
+    assert cfg.settings.output.color == "always"
+
+
+def test_set_config_value_rejects_unknown_key(tmp_path):
+    cfg_file = tmp_path / "plbp_config.toml"
+    with pytest.raises(ConfigError):
+        set_config_value(cfg_file, "logging.nope", "x")
+    with pytest.raises(ConfigError):
+        set_config_value(cfg_file, "token", "secret")  # secrets not settable
+
+
+def test_set_config_value_rejects_invalid_value(tmp_path):
+    cfg_file = tmp_path / "plbp_config.toml"
+    with pytest.raises(ConfigError):
+        set_config_value(cfg_file, "output.color", "rainbow")
+
+
+def test_writable_keys_excludes_secrets():
+    keys = writable_keys()
+    assert "output.color" in keys
+    assert "logging.file_level" in keys
+    assert "token" not in keys
 
 
 def test_logging_configures_without_error():
@@ -98,17 +141,17 @@ def test_logging_configures_without_error():
 
 def test_config_file_naming_under_xdg(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    assert paths.config_file() == tmp_path / "pylb" / "pylb_config.toml"
+    assert paths.config_file() == tmp_path / "plbp" / "plbp_config.toml"
 
 
 def test_database_file_naming_under_xdg(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
-    assert paths.database_file() == tmp_path / "pylb" / "pylb_db.db"
+    assert paths.database_file() == tmp_path / "plbp" / "plbp_db.db"
 
 
 def test_state_file_naming_under_xdg(tmp_path, monkeypatch):
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
-    assert paths.state_file("history") == tmp_path / "pylb" / "pylb_history.log"
+    assert paths.state_file("history") == tmp_path / "plbp" / "plbp_history.log"
 
 
 def test_xdg_default_when_unset(monkeypatch):

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -163,3 +163,50 @@ def test_xdg_relative_value_ignored(monkeypatch):
     # Spec: a non-absolute XDG value must be ignored in favor of the default.
     monkeypatch.setenv("XDG_CONFIG_HOME", "relative/not/absolute")
     assert paths.config_home() == Path.home() / ".config"
+
+
+# -- config robustness (review findings) -----------------------------------
+
+
+def test_invalid_value_warns_and_defaults(tmp_path, monkeypatch):
+    # An invalid setting value must never brick loading: dropped + warned.
+    monkeypatch.delenv(TOKEN_ENV_VAR, raising=False)
+    cfg_file = tmp_path / "plbp_config.toml"
+    cfg_file.write_text('[output]\ncolor = "yes"\nformat = "json"\n')
+    cfg = load_config(config_file=str(cfg_file))
+    assert cfg.settings.output.color == "auto"  # invalid value -> default
+    assert cfg.settings.output.format == "json"  # valid sibling survives
+    assert any("output.color" in w for w in cfg.warnings)
+
+
+def test_explicit_config_invalid_toml_raises(tmp_path, monkeypatch):
+    # --config naming an unparseable file is a loud user error (not ignored).
+    monkeypatch.delenv(TOKEN_ENV_VAR, raising=False)
+    cfg_file = tmp_path / "plbp_config.toml"
+    cfg_file.write_text('[output\ncolor = "always"\n')  # unclosed table
+    with pytest.raises(ConfigError):
+        load_config(config_file=str(cfg_file))
+
+
+def test_explicit_config_missing_is_tolerated(tmp_path, monkeypatch):
+    # A missing explicit file stays fine: it's the target `config set` creates.
+    monkeypatch.delenv(TOKEN_ENV_VAR, raising=False)
+    cfg = load_config(config_file=str(tmp_path / "nope.toml"))
+    assert cfg.settings.output.format == "text"
+    assert cfg.warnings == []
+
+
+def test_set_config_value_refuses_corrupt_file(tmp_path):
+    # Never silently rewrite a corrupt config (would destroy user settings).
+    cfg_file = tmp_path / "plbp_config.toml"
+    cfg_file.write_text('[output\ncolor = "always"\n')  # corrupt
+    before = cfg_file.read_text()
+    with pytest.raises(ConfigError):
+        set_config_value(cfg_file, "logging.level", "info")
+    assert cfg_file.read_text() == before  # untouched
+
+
+def test_set_config_value_restricts_permissions(tmp_path):
+    cfg_file = tmp_path / "plbp_config.toml"
+    set_config_value(cfg_file, "output.color", "never")
+    assert (cfg_file.stat().st_mode & 0o777) == 0o600

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,4 +1,4 @@
-"""Tests for the output renderer contract (human / JSON / Markdown)."""
+"""Tests for the output renderer contract (text / JSON / Markdown)."""
 
 import json
 
@@ -25,14 +25,14 @@ def test_markdown_mode_emits_table(capsys):
     assert "| Alpha | WS | 1 |" in out
 
 
-def test_human_mode_writes_to_stdout(capsys):
-    Renderer(OutputMode.HUMAN, no_color=True).render(_result())
+def test_text_mode_writes_to_stdout(capsys):
+    Renderer(OutputMode.TEXT, no_color=True).render(_result())
     out = capsys.readouterr().out
     assert "Alpha" in out
 
 
 def test_message_goes_to_stderr_not_stdout(capsys):
-    Renderer(OutputMode.HUMAN, no_color=True).message("hello")
+    Renderer(OutputMode.TEXT, no_color=True).message("hello")
     captured = capsys.readouterr()
     assert "hello" in captured.err
     assert captured.out == ""


### PR DESCRIPTION
## Phase 1 of 3 — naming + config foundation

Implements the naming + configuration parts of `docs/design/0001-plbp-cli-conventions.md` (the spec from #377). Per the agreed rulings: **hard rename** to `plbp`, **R8** (no secrets in config — `config set` operates on non-secret dotted keys), **keep `markdown`**, **3 phased PRs**.

> ⚠️ **Breaking change** to the CLI merged in #374: the command is renamed `pylb` → `plbp` and the new CLI's env var is `PY_TOKEN` → `PLBP_TOKEN` (the legacy `py-projects` command keeps `PY_TOKEN`).

### Naming
- Entry point `pylb` → **`plbp`** (no alias); XDG namespace + files → `plbp/plbp_config.toml`.
- `auto_envvar_prefix="PLBP"` on the group + explicit flat env vars (`PLBP_OUTPUT`, `PLBP_CONFIG`).
- `-o/--output` default `human` → **`text`** (`markdown` retained as you chose).

### Config foundation
- **`core/settings.py`** — typed pydantic schema for the `[output]` / `[logging]` tables; the single source of truth for validation and for `config set`/`get`.
- **Layered discovery** — system (`$XDG_CONFIG_DIRS`) → user (`$XDG_CONFIG_HOME`) → project (`./plbp_config.toml`); `--config` overrides discovery entirely. Precedence per setting: flag → env → project → user → system → default.
- **`config set`/`get` take dotted keys** — `plbp config set logging.level info`, `plbp config set output.color always`, `plbp config set logging.file_level debug` — validated + coerced; unknown/invalid keys/values rejected (this is the rework of your "leftover token example").
- **R8** — secrets never in config: token resolves from `--token` or `$PLBP_TOKEN` only; token-in-file reading and `config set token` are removed.

### Scope boundary
Phase 1 establishes the config *substrate*. **Wiring settings into behaviour comes next:** color resolution + `--output-file` in Phase 2, dual-sink rotating logging in Phase 3. So `config set output.color` is accepted and stored now, but doesn't change rendering until Phase 2 (noted intentionally).

### Validation
ruff + ty clean · pytest **73 passed** (layered discovery, precedence, nested set/get, env resolution, token-not-from-file) · codespell · `manifest-drift: ok` (registered `core/settings.py`) · init/tests **68 passed**.

### Notes
- **ADRs** for the rename and "no secrets in config" will land once #377 (which creates `docs/adr/`) is merged — I kept this branch off `main` to avoid stacking. Happy to add them here if you'd rather merge #377 first.
- Depends conceptually on #377 (the spec doc); functionally independent.

https://claude.ai/code/session_01XRniMePWXYykS8xN1Yrwbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRniMePWXYykS8xN1Yrwbr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CLI rebranded from `pylb` to `plbp`
  * XDG-based TOML configuration support at `~/.config/plbp/plbp_config.toml`
  * Enhanced `config` command with get/set operations for nested configuration keys
  * Layered configuration system with system/user/project precedence

* **Breaking Changes**
  * Default output mode changed from "human" to "text"
  * Tokens now supplied only via `--token` flag or `$PLBP_TOKEN` environment variable
  * Environment variable prefix changed to `PLBP_*` (e.g., `PLBP_CONFIG`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->