### PR TITLE
docs: backfill ADRs, flip spec to implemented, link POST_INIT from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Install as a tool: `uvx --from py-launch-blueprint py-projects` (uvx needs `--fr
 
 See [AGENTS.md](AGENTS.md) for the canonical command set, [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) for the daily workflow, and [RELEASE.md](RELEASE.md) for the release flow.
 
-**Starting a new project from this template?** If you use Claude Code or any agent that reads `AGENTS.md`, just say *"create a new Python project from py-launch-blueprint"* — the [`skill/`](skill/SKILL.md) skill will walk you through `gh repo create --template`, identity collection, `just init` rebrand with preview, and an optional handoff to `just post-init` for publishing/Codecov/ReadTheDocs setup. For humans without an agent: the skill is also a copy-pasteable runbook.
+**Starting a new project from this template?** If you use Claude Code or any agent that reads `AGENTS.md`, just say *"create a new Python project from py-launch-blueprint"* — the [`skill/`](skill/SKILL.md) skill will walk you through `gh repo create --template`, identity collection, `just init` rebrand with preview, and an optional handoff to `just post-init` for publishing/Codecov/ReadTheDocs setup. For humans without an agent: the skill is also a copy-pasteable runbook. After init, work through [`POST_INIT.md`](POST_INIT.md) — the checklist of decisions, secrets, and repo settings to configure. Internal engineering docs (ADRs, design specs, research) live under [`docs/`](docs/README.md).
 
 ### 🎯 Perfect For
 Teams and professionals needing maintainable, type-safe Python projects following best practices.

--- a/docs/adr/0001-app-short-name-plbp.md
+++ b/docs/adr/0001-app-short-name-plbp.md
@@ -1,0 +1,35 @@
+# 0001. App short name `plbp` (hard rename from `pylb`)
+
+- **Status:** Accepted
+- **Date:** 2026-06-09
+- **Deciders:** maintainer (interactive), implemented in PR #378
+- **Related:** [design 0001](../design/0001-plbp-cli-conventions.md) §0–§1; ADR 0002
+
+## Context
+
+The modern noun-verb CLI shipped as `pylb` with a `PY_TOKEN` env var, while
+the conventions spec (design 0001) standardized on the short name **`plbp`**
+with a **`PLBP_*`** env prefix. The name is load-bearing: it is the console
+command, the uppercased env-var prefix, the XDG namespace
+(`~/.config/<app>/`), and the file-name prefix (`<app>_config.toml`,
+`<app>.log`). Two names cannot coexist without confusing every doc and fork.
+
+## Decision
+
+Rename to `plbp`/`PLBP_*` everywhere, as a **hard rename** — no `pylb`
+back-compat alias. The legacy single-command example (`py-projects`) keeps
+its own name and `PY_TOKEN` for back-compat; it is a separate entry point.
+
+## Consequences
+
+- Breaking change for anyone invoking `pylb` (released as v2.0.0).
+- One spelling across spec, code, docs, and the init rebrand system.
+- The app name became a tracked init identity so forks rename it wholesale
+  (see the `app_name` / `app_name_upper` fields in `init/manifest.toml`).
+
+## Alternatives considered
+
+- **Keep `pylb`, adapt the spec** — rejected: the spec's name was chosen
+  deliberately; adapting docs to an accidental name inverts the authority.
+- **Ship both (`pylb` deprecated alias)** — rejected: a template should not
+  teach forks to carry alias debt from day one.

--- a/docs/adr/0002-no-secrets-in-config-file.md
+++ b/docs/adr/0002-no-secrets-in-config-file.md
@@ -1,0 +1,37 @@
+# 0002. Secrets are never stored in the config file
+
+- **Status:** Accepted
+- **Date:** 2026-06-09
+- **Deciders:** maintainer (interactive), implemented in PR #378
+- **Related:** [design 0001](../design/0001-plbp-cli-conventions.md) §8 (R8)
+
+## Context
+
+An early iteration of the CLI both read the auth token from the TOML config
+file and offered `config set token <value>` to write it there. Spec R8 says
+secrets live in the `--token` flag or `$PLBP_TOKEN` env var only: config
+files get copied, committed, backed up, and shared in ways secret stores are
+not, and a "convenient" token-in-file path normalizes leaking.
+
+## Decision
+
+The token resolves from `--token` then `$PLBP_TOKEN` — **never** from a
+file; a `token` key found in config is silently ignored by the loader.
+`config set`/`config get` operate only on the typed, non-secret settings
+schema (`[output]`, `[logging]`), so a secret cannot even be named as a key.
+The config file is still written `0600` as defense-in-depth, because users
+put sensitive things in CLI config files out of habit.
+
+## Consequences
+
+- Removed a shipped feature (`config set token`) — a deliberate reversal.
+- Setup docs must say "export PLBP_TOKEN" instead of "run config set".
+- `doctor` reports token presence/source so the env-only path stays
+  debuggable.
+
+## Alternatives considered
+
+- **Keep token-in-file as a convenience** — rejected: convenience here is
+  the attack surface.
+- **OS keyring integration** — out of scope for a template; the env-var
+  contract composes with any secret manager.

--- a/docs/adr/0003-keep-markdown-output-mode.md
+++ b/docs/adr/0003-keep-markdown-output-mode.md
@@ -1,0 +1,36 @@
+# 0003. Keep `markdown` as a third output format (spec deviation)
+
+- **Status:** Accepted
+- **Date:** 2026-06-09
+- **Deciders:** maintainer (interactive), implemented in PR #378
+- **Related:** [design 0001](../design/0001-plbp-cli-conventions.md) §3 (R3.2)
+
+## Context
+
+Spec R3.2 allows exactly two output formats: `text` (default) and `json`.
+The CLI had already shipped a third, `markdown`, rendering any result model
+as a GitHub-flavored table — useful for pasting into issues/PRs and cheap to
+maintain because every command renders through one `Renderer` and one result
+model.
+
+## Decision
+
+Keep `markdown` as a deliberate superset of the spec:
+`-o text|json|markdown`, default `text`. The config schema
+(`output.format`) accepts the same three values.
+
+## Consequences
+
+- The spec and implementation intentionally differ on R3.2; design 0001
+  carries a deviation note pointing here.
+- Every future result model must keep rendering through the shared
+  table-shape contract (columns/rows), which is what makes the third format
+  free.
+
+## Alternatives considered
+
+- **Strict spec compliance (drop markdown)** — rejected: removing a shipped,
+  zero-marginal-cost format to satisfy a list the spec can simply note.
+- **Add it to the spec instead** — equivalent outcome; the deviation note +
+  this ADR records the decision without rewriting a versioned requirements
+  doc.

--- a/docs/adr/0004-config-errors-degrade-to-warnings.md
+++ b/docs/adr/0004-config-errors-degrade-to-warnings.md
@@ -1,0 +1,45 @@
+# 0004. Invalid config values degrade to warnings, never crashes
+
+- **Status:** Accepted
+- **Date:** 2026-06-10
+- **Deciders:** maintainer (via code-review batch), implemented post-review in PR #378/#379
+- **Related:** [design 0001](../design/0001-plbp-cli-conventions.md) §6–§7
+
+## Context
+
+Config loading runs eagerly on every invocation (output format, color, and
+log levels resolve from it). A review found that one invalid value in any
+layer made **every** command crash with a raw validation traceback —
+including `config set`, the tool needed to repair the file. Conversely,
+silently ignoring problems (the other failure found: an explicit `--config`
+with broken TOML read as empty) hides user errors.
+
+## Decision
+
+Tiered strictness:
+
+1. **Invalid values** (right TOML, wrong value) → drop the key, keep valid
+   siblings, emit a warning on stderr; the command proceeds on defaults.
+2. **Unparsable discovered layers** (system/user/project) → skip the layer
+   with a warning.
+3. **Unparsable explicit `--config` file** → loud `ConfigError` (the user
+   named it; nothing else will supply what they wrote). Missing explicit
+   files stay tolerated — they are valid `config set` targets.
+4. **Writes refuse corrupt files** — `config set` never rewrites a file it
+   cannot parse (that would destroy the user's other settings).
+5. Errors raised while building the invocation context render through a
+   fallback renderer with `ExitCode.CONFIG` — never a traceback.
+
+## Consequences
+
+- The CLI is always able to inspect and repair its own configuration.
+- `Config.warnings` is part of the loader's contract; front-ends must
+  surface it.
+- Hard failures are reserved for explicit user input and destructive writes.
+
+## Alternatives considered
+
+- **Strict everywhere (raise on any invalid value)** — rejected: bricks the
+  repair path; a stray project-local file in cwd could disable the CLI.
+- **Tolerant everywhere** — rejected: silently ignoring an explicitly named
+  config file or rewriting a corrupt one loses user data/trust.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,7 +19,10 @@ Start from [`template.md`](template.md).
 
 | ADR | Title | Status |
 |-----|-------|--------|
-| —   | _none yet_ | — |
+| [0001](0001-app-short-name-plbp.md) | App short name `plbp` (hard rename from `pylb`) | Accepted |
+| [0002](0002-no-secrets-in-config-file.md) | Secrets are never stored in the config file | Accepted |
+| [0003](0003-keep-markdown-output-mode.md) | Keep `markdown` as a third output format (spec deviation) | Accepted |
+| [0004](0004-config-errors-degrade-to-warnings.md) | Invalid config values degrade to warnings, never crashes | Accepted |
 
 ## Note on historical decisions
 

--- a/docs/design/0001-plbp-cli-conventions.md
+++ b/docs/design/0001-plbp-cli-conventions.md
@@ -1,15 +1,18 @@
 # `plbp` CLI Conventions — Requirements
 
-- **Status:** Proposed
+- **Status:** Implemented (PRs #378–#380; naming per [ADR 0001](../adr/0001-app-short-name-plbp.md))
 - **Type:** Design / requirements spec
 - **Created:** 2026-06-09
-- **Applies to:** the py-launch-blueprint CLI (currently shipped as `pylb`)
+- **Applies to:** the py-launch-blueprint CLI (`plbp`)
 
-> **Implementation note.** This spec uses the app short name **`plbp`** and env
-> prefix **`PLBP`**, whereas the CLI merged so far ships as **`pylb`** with a
-> `PY_TOKEN` env var. Reconciling the names (rename to `plbp` / `PLBP_*`, or keep
-> `pylb` and adapt this spec) is the first thing to settle when implementing —
-> see Appendix D. The requirements below are the normative target either way.
+> **Deviations from this spec, all deliberate:**
+> 1. **R3.2** — a third output format, `markdown`, is kept in addition to
+>    `text`/`json` ([ADR 0003](../adr/0003-keep-markdown-output-mode.md)).
+> 2. **R6/R7 strictness** — invalid config *values* degrade to warnings
+>    rather than errors so the CLI can always repair its own config; an
+>    unparsable explicit `--config` file is a hard error
+>    ([ADR 0004](../adr/0004-config-errors-degrade-to-warnings.md)).
+> 3. Secrets policy implemented per **R8** ([ADR 0002](../adr/0002-no-secrets-in-config-file.md)).
 
 Scope: output, color, configuration (TOML), and logging conventions for the
 `py-launch-blueprint` CLI. App short name: **`plbp`**. Environment variable

--- a/init/manifest.toml
+++ b/init/manifest.toml
@@ -73,7 +73,7 @@ files   = [
 ]
 mode    = "structured"
 
-# app_name (text) — 176 occurrences in 18 files
+# app_name (text) — 185 occurrences in 23 files
 # NOTE: 4-char token — safe for text mode because "plbp" was invented to be
 # substring-disjoint from real words and every other identity value.
 [[replace]]
@@ -82,6 +82,11 @@ current = ["plbp"]
 files   = [
   "EXAMPLECLI.md",   # 36x
   "docs/design/0001-plbp-cli-conventions.md",   # 28x
+  "docs/adr/0001-app-short-name-plbp.md",   # 4x
+  "docs/adr/0002-no-secrets-in-config-file.md",   # 1x
+  "docs/adr/0003-keep-markdown-output-mode.md",   # 1x
+  "docs/adr/0004-config-errors-degrade-to-warnings.md",   # 1x
+  "docs/adr/README.md",   # 2x
   "docs/design/README.md",   # 2x
   "POST_INIT.md",   # 1x
   "src/py_launch_blueprint/cli/commands/__init__.py",   # 1x
@@ -101,7 +106,7 @@ files   = [
 ]
 mode    = "text"
 
-# app_name_upper (text) — 106 occurrences in 12 files
+# app_name_upper (text) — 111 occurrences in 14 files
 # Derived identity (app_name.upper()): the PLBP_* env prefix and the
 # _PLBP_COMPLETE completion var. Never prompted; init derives it.
 [[replace]]
@@ -110,6 +115,8 @@ current = ["PLBP"]
 files   = [
   "EXAMPLECLI.md",   # 12x
   "docs/design/0001-plbp-cli-conventions.md",   # 26x
+  "docs/adr/0001-app-short-name-plbp.md",   # 2x
+  "docs/adr/0002-no-secrets-in-config-file.md",   # 3x
   "POST_INIT.md",   # 1x
   "src/py_launch_blueprint/cli/commands/config.py",   # 2x
   "src/py_launch_blueprint/cli/commands/projects.py",   # 1x
@@ -132,12 +139,13 @@ files   = [
 ]
 mode    = "structured"
 
-# command_name (text) — 30 occurrences in 8 files
+# command_name (text) — 31 occurrences in 9 files
 [[replace]]
 field   = "command_name"
 current = ["py-projects"]
 files   = [
   ".github/CONTRIBUTING.md",   # 1x
+  "docs/adr/0001-app-short-name-plbp.md",   # 1x
   ".windsurfrules",   # 1x
   "EXAMPLECLI.md",   # 11x
   "Justfile",   # 1x
@@ -323,6 +331,10 @@ to   = "assets/images/logos/{package_name}_logo_150x150.png"
 [[rename]]
 from = "assets/images/logos/py_launch_blueprint_logo_100x100.png"
 to   = "assets/images/logos/{package_name}_logo_100x100.png"
+
+[[rename]]
+from = "docs/adr/0001-app-short-name-plbp.md"
+to   = "docs/adr/0001-app-short-name-{app_name}.md"
 
 [[rename]]
 from = "docs/design/0001-plbp-cli-conventions.md"


### PR DESCRIPTION
## What

Items **2 + 5** from the follow-up list:

- **ADRs 0001–0004 backfilled** — the four load-bearing decisions from the CLI conventions work, recorded while fresh: app short name `plbp` (hard rename), secrets never in the config file (R8), `markdown` kept as a third output format (deliberate spec deviation), and the tiered config-error strictness from the review fixes (warn / skip / raise / refuse). Index table populated — `docs/adr/` is no longer empty scaffolding.
- **`docs/design/0001` → Implemented** — the stale "reconcile the naming first" note is replaced with the recorded deviations, each linking its ADR.
- **README** now links `POST_INIT.md` (post-fork checklist) and `docs/README.md` (internal docs root) from the template-onboarding paragraph — the open question from #376.

## Rebrand coverage

The ADRs carry `plbp`/`PLBP`/`py-projects` occurrences, so they're registered in the manifest (precedent: CHANGELOG is also rebranded historical content), including a `[[rename]]` for ADR 0001's `plbp`-bearing filename. Verified by full rebrand: `no-identity-leak: ok`, fork gets `docs/adr/0001-app-short-name-widget.md` with the index link intact.

## Validation
manifest-drift ok · codespell ok · init/tests 72 passed · full rebrand clean.

https://claude.ai/code/session_01XRniMePWXYykS8xN1Yrwbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRniMePWXYykS8xN1Yrwbr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced project setup guidance with references to the initialization checklist and internal documentation structure.
  * Added architectural decision records documenting key behaviors: app naming standardization, graceful configuration error handling, supported output formats, and secrets management policies.
  * Updated the design specification to "Implemented" status and documented deviations from the original specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->