### PR TITLE
refactor(cli): single-source vocabularies, honest config-get source, one-parse config set

### DIFF
--- a/src/py_launch_blueprint/cli/commands/config.py
+++ b/src/py_launch_blueprint/cli/commands/config.py
@@ -30,8 +30,8 @@ from py_launch_blueprint.cli.context import AppContext
 from py_launch_blueprint.cli.options import confirm, global_options, mutation_options
 from py_launch_blueprint.core.config import (
     get_default_config_path,
-    get_file_value,
-    set_config_value,
+    read_config_for_write,
+    write_config_data,
 )
 from py_launch_blueprint.core.errors import ExitCode
 from py_launch_blueprint.core.models import ConfigPath, ConfigValue
@@ -76,8 +76,13 @@ def config_get(app: AppContext, key: str) -> None:
         app.renderer.render(ConfigValue(key=key, value=value, source=cfg.source))
         return
     section, name = parse_key(key)
-    resolved = getattr(getattr(cfg.settings, section), name)
-    app.renderer.render(ConfigValue(key=key, value=str(resolved), source="config"))
+    table = getattr(cfg.settings, section)
+    resolved = getattr(table, name)
+    # model_fields_set tracks keys a config layer actually supplied — anything
+    # else is the schema default, and claiming "config" for it sends users
+    # hunting for a file that doesn't set it.
+    source = "config" if name in table.model_fields_set else "default"
+    app.renderer.render(ConfigValue(key=key, value=str(resolved), source=source))
 
 
 @config_group.command(name="set")
@@ -107,7 +112,13 @@ def config_set(
         app.renderer.render(ConfigValue(key=key, value=str(coerced), source="dry-run"))
         return
 
-    existing = get_file_value(path, key)
+    # One read serves both the overwrite check and the write — the value
+    # shown in the prompt is the value the write preserves around.
+    data = read_config_for_write(path)  # ConfigError if existing+corrupt
+    table = data.get(section)
+    if not isinstance(table, dict):
+        table = {}
+    existing = table.get(name)
     if (
         existing is not None
         and existing != coerced
@@ -120,7 +131,9 @@ def config_set(
         app.renderer.message("Aborted.")
         raise SystemExit(int(ExitCode.INTERRUPT))
 
-    set_config_value(path, key, value)
+    table[name] = coerced
+    data[section] = table
+    write_config_data(path, data)
     app.renderer.message(f"Set {key} = {coerced} in {path}")
     app.renderer.render(ConfigValue(key=key, value=str(coerced), source="file"))
 

--- a/src/py_launch_blueprint/cli/options.py
+++ b/src/py_launch_blueprint/cli/options.py
@@ -34,6 +34,7 @@ import click
 from py_launch_blueprint.cli.context import LOG_FILE_DEFAULT_SENTINEL, AppContext
 from py_launch_blueprint.cli.output import OutputMode, Renderer
 from py_launch_blueprint.core.errors import ConfigError, ExitCode, PyError
+from py_launch_blueprint.core.logging import LOG_LEVELS
 
 _OUTPUT_CHOICES = [mode.value for mode in OutputMode]
 
@@ -70,7 +71,7 @@ _GLOBAL_OPTIONS: list[Callable[[Any], Any]] = [
     click.option(
         "--log-level",
         "log_level",
-        type=click.Choice(["debug", "info", "warning", "error", "critical"]),
+        type=click.Choice(list(LOG_LEVELS)),
         default=None,
         envvar="PLBP_LOG_LEVEL",
         help="Explicit console log level (overrides -v/-q).",

--- a/src/py_launch_blueprint/core/config.py
+++ b/src/py_launch_blueprint/core/config.py
@@ -34,7 +34,9 @@ Secrets are **never** stored in the config file (R8): the token resolves from
 *loads* and *writes* configuration; it never prints.
 """
 
+import contextlib
 import os
+import tempfile
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -209,15 +211,29 @@ def read_config_for_write(config_path: Path) -> dict[str, Any]:
 
 
 def write_config_data(config_path: Path, data: dict[str, Any]) -> None:
-    """Write a config dict as TOML, creating the parent dir (0700).
+    """Write a config dict as TOML, atomically, restricted to the owner.
 
-    The file is restricted to the owner (0600): users habitually put
-    sensitive things in CLI config files even though the schema holds no
-    secrets.
+    Writes to a temp file in the same directory and ``os.replace``s it over
+    the target, so an interrupted write can never leave a truncated config
+    (which ``config set`` would then refuse to touch). ``mkstemp`` creates
+    the file 0600 from the first byte — users habitually put sensitive
+    things in CLI config files even though the schema holds no secrets.
     """
     config_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    config_path.write_text(tomli_w.dumps(data), encoding="utf-8")
-    config_path.chmod(0o600)
+    rendered = tomli_w.dumps(data)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=config_path.parent, prefix=f".{config_path.name}."
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(rendered)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, config_path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
 
 
 def set_config_value(config_path: Path, dotted_key: str, raw_value: str) -> Any:

--- a/src/py_launch_blueprint/core/config.py
+++ b/src/py_launch_blueprint/core/config.py
@@ -190,36 +190,50 @@ def get_file_value(config_path: Path, dotted_key: str) -> Any:
     return None
 
 
+def read_config_for_write(config_path: Path) -> dict[str, Any]:
+    """Read a config file that is about to be modified.
+
+    Missing files read as ``{}`` (a valid ``config set`` target). A file that
+    exists but cannot be parsed raises :class:`ConfigError` — never silently
+    rewrite a corrupt file, which would destroy whatever the user had in it.
+    """
+    if not config_path.exists():
+        return {}
+    try:
+        return tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise ConfigError(
+            f"refusing to modify {config_path}: existing file cannot be "
+            f"parsed ({exc}). Fix or remove it first."
+        ) from exc
+
+
+def write_config_data(config_path: Path, data: dict[str, Any]) -> None:
+    """Write a config dict as TOML, creating the parent dir (0700).
+
+    The file is restricted to the owner (0600): users habitually put
+    sensitive things in CLI config files even though the schema holds no
+    secrets.
+    """
+    config_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    config_path.write_text(tomli_w.dumps(data), encoding="utf-8")
+    config_path.chmod(0o600)
+
+
 def set_config_value(config_path: Path, dotted_key: str, raw_value: str) -> Any:
     """Validate + write one ``section.key`` into the TOML file, preserving rest.
 
     Returns the coerced value. Raises :class:`ConfigError` for unknown keys,
     invalid values (secrets are not part of the schema, so cannot be set
-    here), or an existing file that cannot be parsed — never silently
-    rewrite a corrupt file, which would destroy whatever the user had in it.
+    here), or a corrupt existing file (see :func:`read_config_for_write`).
     """
     section, key = parse_key(dotted_key)
     value = coerce_value(section, key, raw_value)
-
-    if config_path.exists():
-        try:
-            data = tomllib.loads(config_path.read_text(encoding="utf-8"))
-        except (OSError, tomllib.TOMLDecodeError) as exc:
-            raise ConfigError(
-                f"refusing to modify {config_path}: existing file cannot be "
-                f"parsed ({exc}). Fix or remove it first."
-            ) from exc
-    else:
-        data = {}
+    data = read_config_for_write(config_path)
     table = data.get(section)
     if not isinstance(table, dict):
         table = {}
     table[key] = value
     data[section] = table
-
-    config_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    config_path.write_text(tomli_w.dumps(data), encoding="utf-8")
-    # Restrict to the owner: users habitually put sensitive things in CLI
-    # config files even though the schema holds no secrets.
-    config_path.chmod(0o600)
+    write_config_data(config_path, data)
     return value

--- a/tests/cli/test_pylb.py
+++ b/tests/cli/test_pylb.py
@@ -475,3 +475,23 @@ def test_log_format_env_case_insensitive(runner, tmp_path, monkeypatch):
     assert result.exit_code == 0
     line = log.read_text().strip().splitlines()[0]
     json.loads(line)  # JSONL, not text: the env value was normalized
+
+
+def test_config_get_reports_default_source(runner, tmp_path, monkeypatch):
+    # A built-in default must not claim a config file provided it.
+    monkeypatch.delenv("PLBP_TOKEN", raising=False)
+    cfg = tmp_path / "plbp_config.toml"  # does not exist
+    result = runner.invoke(
+        cli, ["config", "get", "logging.level", "--config", str(cfg), "--json"]
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["value"] == "warning"
+    assert payload["source"] == "default"
+    # ...and a file-provided value still reports "config".
+    cfg.write_text('[logging]\nlevel = "info"\n')
+    result = runner.invoke(
+        cli, ["config", "get", "logging.level", "--config", str(cfg), "--json"]
+    )
+    payload = json.loads(result.output)
+    assert payload["source"] == "config"

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -237,3 +237,12 @@ def test_output_format_vocabularies_stay_in_sync():
 
     literal = get_args(OutputSettings.model_fields["format"].annotation)
     assert tuple(m.value for m in OutputMode) == literal
+
+
+def test_write_leaves_no_temp_files(tmp_path):
+    # Atomic write: only the config file remains after a set.
+    cfg_file = tmp_path / "plbp_config.toml"
+    set_config_value(cfg_file, "output.color", "never")
+    set_config_value(cfg_file, "logging.level", "info")
+    assert [p.name for p in tmp_path.iterdir()] == ["plbp_config.toml"]
+    assert (cfg_file.stat().st_mode & 0o777) == 0o600

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -210,3 +210,30 @@ def test_set_config_value_restricts_permissions(tmp_path):
     cfg_file = tmp_path / "plbp_config.toml"
     set_config_value(cfg_file, "output.color", "never")
     assert (cfg_file.stat().st_mode & 0o777) == 0o600
+
+
+# -- vocabulary single-sourcing guards (review findings) ---------------------
+
+
+def test_log_level_vocabularies_stay_in_sync():
+    # The settings Literal and LOG_LEVELS must agree; the click choices
+    # derive from LOG_LEVELS directly.
+    from typing import get_args
+
+    from py_launch_blueprint.core.logging import LOG_LEVELS
+    from py_launch_blueprint.core.settings import LoggingSettings
+
+    literal = get_args(LoggingSettings.model_fields["level"].annotation)
+    assert tuple(LOG_LEVELS) == literal
+    file_literal = get_args(LoggingSettings.model_fields["file_level"].annotation)
+    assert tuple(LOG_LEVELS) == file_literal
+
+
+def test_output_format_vocabularies_stay_in_sync():
+    from typing import get_args
+
+    from py_launch_blueprint.cli.output import OutputMode
+    from py_launch_blueprint.core.settings import OutputSettings
+
+    literal = get_args(OutputSettings.model_fields["format"].annotation)
+    assert tuple(m.value for m in OutputMode) == literal


### PR DESCRIPTION
## What

Item **4** from the follow-up list — the code-review cleanups that the 10-finding cap cut:

| Cleanup | Fix |
|---|---|
| Log-level vocabulary in 3 places | `--log-level` choices now derive from `LOG_LEVELS`; the settings Literals are **test-pinned** to `LOG_LEVELS` and `OutputMode`, so adding a level/format in one place fails fast instead of drifting into a runtime `KeyError`/`ValueError` |
| `config get` claims `source: "config"` for built-in defaults | Reports `"default"` via pydantic `model_fields_set` (no extra file I/O) — users stop hunting for a config file that doesn't set the value |
| `config set` parses the same TOML 3× and coerces 2× | One read serves the overwrite-confirmation and the write (`read_config_for_write` + `write_config_data` in core; `set_config_value` composes them) — the prompt and the write can no longer disagree |

Note on the Literals: they stay as explicit literal strings (static type checking requires it) — the single-sourcing is enforced by sync tests rather than runtime derivation, keeping the code straightforward.

## Validation
ruff + ty clean · pytest **113 passed** (3 new: two vocabulary sync guards, default-vs-config source) · manifest-drift ok · codespell ok.

https://claude.ai/code/session_01XRniMePWXYykS8xN1Yrwbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRniMePWXYykS8xN1Yrwbr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `config get` now indicates whether each value comes from defaults or your config file.

* **Bug Fixes**
  * More reliable, atomic config file writes that avoid leftover temp files and enforce restrictive permissions.
  * Log-level CLI choices now align with the application’s accepted log levels.

* **Tests**
  * Added tests for config source reporting, write-atomicity/permissions, and consistent vocabularies across config and CLI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->