### PR TITLE
docs(projects): capture P01 — init app-name rebrand robustness (B+C)

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -20,8 +20,9 @@ file by hand — see Conventions.
 
 ## Projects
 
-_No projects captured yet. Use `project-add` to capture the first idea — it
-reserves the next `P##` and writes the stub in one atomic commit._
+| ID  | St    | Project                                                                 |
+|-----|-------|------------------------------------------------------------------------|
+| P01 | `[ ]` | [Init app-name rebrand robustness](projects/P01-init-rebrand-robustness.md) — per-field drift coverage (B) + derive non-contract internals (C) |
 
 ## Conventions
 

--- a/init/manifest.toml
+++ b/init/manifest.toml
@@ -73,7 +73,7 @@ files   = [
 ]
 mode    = "structured"
 
-# app_name (text) — 185 occurrences in 23 files
+# app_name (text) — 193 occurrences in 24 files
 # NOTE: 4-char token — safe for text mode because "plbp" was invented to be
 # substring-disjoint from real words and every other identity value.
 [[replace]]
@@ -103,10 +103,11 @@ files   = [
   "tests/conftest.py",   # 1x
   "tests/core/test_core.py",   # 17x
   "tests/core/test_logging.py",   # 8x
+  "projects/P01-init-rebrand-robustness.md",   # 8x
 ]
 mode    = "text"
 
-# app_name_upper (text) — 111 occurrences in 14 files
+# app_name_upper (text) — 123 occurrences in 15 files
 # Derived identity (app_name.upper()): the PLBP_* env prefix and the
 # _PLBP_COMPLETE completion var. Never prompted; init derives it.
 [[replace]]
@@ -127,6 +128,7 @@ files   = [
   "src/py_launch_blueprint/core/logging.py",   # 1x
   "src/py_launch_blueprint/core/settings.py",   # 1x
   "tests/cli/test_pylb.py",   # 38x
+  "projects/P01-init-rebrand-robustness.md",   # 12x
 ]
 mode    = "text"
 
@@ -206,7 +208,7 @@ files   = [
 ]
 mode    = "structured"
 
-# package_name (text) — 95 occurrences in 36 files
+# package_name (text) — 96 occurrences in 37 files
 [[replace]]
 field   = "package_name"
 current = ["py_launch_blueprint"]
@@ -270,6 +272,7 @@ files   = [
   "tests/test_config.py",   # 1x
   "tests/test_output.py",   # 1x
   "tests/test_version_consistency.py",   # 2x
+  "projects/P01-init-rebrand-robustness.md",   # 1x
 ]
 mode    = "text"
 

--- a/projects/P01-init-rebrand-robustness.md
+++ b/projects/P01-init-rebrand-robustness.md
@@ -1,0 +1,95 @@
+# P01 — Init app-name rebrand robustness
+
+- **Status:** `[ ]` scoped, not started
+- **Captured:** 2026-06-10
+- **Scope:** init rebrand system (`init/`), CLI internals (`src/py_launch_blueprint/`)
+
+## Problem
+
+The init rebrand system replaces identity literals (`plbp`, `PLBP`, …) per
+*field*: the engine (`init/_engine.py`) rewrites each value **only in the files
+listed under that value's `[[replace]]` block**. But the drift guard
+(`init/ci/check_manifest_drift.py`) verifies coverage against a **flat union**
+of all blocks' files (it builds one `covered_files` set and `continue`s on any
+match), so it never checks that a file containing `PLBP` is listed under the
+`app_name_upper` field specifically.
+
+Result — a verified failure mode: a file listed under `app_name` (lowercase)
+but not `app_name_upper` (uppercase) that contains a `PLBP_*` literal passes
+drift, yet a fork ships half-renamed (`widget` command still reading `PLBP_*`).
+This was hit twice during the CLI work (`_plbp_owned` in `core/logging.py`,
+`plbp` in `tests/conftest.py`) and only caught by the slow full-rebrand
+integration run, not the fast checker.
+
+## Plan: B + C
+
+### B — per-field drift coverage (the deep fix)
+
+Make the verifier match the engine. In `check_manifest_drift.py`, build
+per-*value* coverage instead of a flat union:
+
+```python
+covered_by_value: dict[str, set[Path]] = {}
+for op in manifest.replaces:
+    files = {(REPO_ROOT / f).resolve() for f in op.files}
+    for value in op.current:
+        covered_by_value.setdefault(value, set()).update(files)
+# per repo file: for each identity value present, require coverage under THAT value
+```
+
+Also stop blanket-skipping `[[rename]]` source files for the content check — a
+rename moves the *filename*, not the `plbp`/`PLBP` occurrences inside the file
+(e.g. `docs/design/0001-…` is both renamed and content-replaced), so content
+coverage must be verified independently.
+
+No `src/` changes; every literal stays greppable. Acceptance: a fixture repo
+with one deliberately half-covered file makes the checker exit non-zero with a
+message naming the exact missing field/list.
+
+### C — derive only the three non-contract internals
+
+Derive from `paths.APP_NAME` the three literals nobody greps in docs/scripts,
+removing the highest-risk incidental trap sites:
+
+- `cli/main.py`: `_COMPLETE_VAR = "_PLBP_COMPLETE"` → `f"_{APP_NAME.upper()}_COMPLETE"`
+- `cli/main.py`: `auto_envvar_prefix: "PLBP"` → `APP_NAME.upper()`
+- `core/logging.py`: the `_plbp_owned` handler marker → `_OWNED_FLAG = f"_{APP_NAME}_owned"` + `setattr`/`getattr`
+
+Leaves all **user-facing** env-var literals (`PLBP_TOKEN`, `PLBP_OUTPUT`, …)
+explicit so `grep PLBP_TOKEN src/` keeps working. `core/logging.py` drops out
+of the `app_name` replace list as a bonus.
+
+## Out of scope: A (full derivation) — rejected, with rationale
+
+Deriving every env-var name from `APP_NAME` (`envvar=f"{ENV_PREFIX}_OUTPUT"`,
+`TOKEN_ENV_VAR = f"{ENV_PREFIX}_TOKEN"`, …) was considered and rejected:
+
+1. Kills greppability in a **template** whose purpose is to be read/learned/copied.
+2. Doesn't eliminate the manifest — docs, the spec, ADRs, CHANGELOG, and tests
+   keep literal `plbp`/`PLBP_*` (you can't derive prose; tests *should* assert
+   the literal contract). ~10 of ~50 entries removed; machinery survives.
+3. Tests that assert `setenv(f"{ENV_PREFIX}_OUTPUT")` test nothing — so the
+   test files stay literal and keep the half-rename risk B already fixes.
+4. ~1–2 days incl. re-running the whole rebrand integration matrix.
+
+B is the deeper fix because the real mechanism is *verification matching the
+engine*, not name derivation.
+
+## Acceptance criteria
+
+- [ ] Drift checker fails when a file contains an identity value not covered
+      under that value's own field (regression fixture test).
+- [ ] Drift checker verifies content coverage independently of `[[rename]]`.
+- [ ] `_COMPLETE_VAR`, `auto_envvar_prefix`, and the logging owner-marker derive
+      from `APP_NAME`; `core/logging.py` carries no `plbp`/`PLBP` literal.
+- [ ] User-facing env-var literals unchanged and still greppable.
+- [ ] Full rebrand integration still reports `no-identity-leak: ok`.
+
+## References
+
+- Failure mode confirmed in `init/ci/check_manifest_drift.py` (flat-union
+  coverage) and `init/_engine.py` (`apply_replace_text` applies only
+  `op.current` to `op.files`).
+- Originated from the high-effort code review of the `plbp` CLI stack
+  (PRs #378–#381); the review's "altitude" finding framed it as derive-vs-
+  special-case, resolved here as verify-vs-derive.


### PR DESCRIPTION
## What

Captures **P01** in the `project-harness` trunk — the deferred follow-up (**B+C**) from the `plbp` CLI code review, tracked for later rather than implemented now.

- `PROJECTS.md`: P01 row, status `[ ]` scoped-not-started.
- `projects/P01-init-rebrand-robustness.md`: the full plan — the verified failure mode (the drift checker's flat-union coverage vs. the engine's per-field replacement), **B** (per-field drift coverage, with the code sketch) + **C** (derive the three non-contract internals from `APP_NAME`), the rationale for rejecting **A** (full derivation), and acceptance criteria.

## Why a PR (and a manifest change) for a planning note

`main` is protected, and the `project-add` skill isn't loaded in this session, so I applied the documented trunk + per-file convention by hand. The note discusses `plbp`/`PLBP`/`py_launch_blueprint` as its subject, so the drift guard (which scans `projects/`) requires coverage — registered under `app_name` (8×) / `app_name_upper` (12×) / `package_name` (1×), exactly as the design doc and ADRs were. Verified by full rebrand: it becomes `widget`/`WIDGET`/`acme_widget` with `no-identity-leak: ok`.

## Note
Pure tracking — no behavior change. The actual B+C implementation is the work this reserves; start it whenever you like (or `project-refine` it further).

manifest-drift ok · init/tests 72 · codespell ok.

https://claude.ai/code/session_01XRniMePWXYykS8xN1Yrwbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRniMePWXYykS8xN1Yrwbr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added first project entry (P01: Init app-name rebrand robustness) to projects tracking list with status indicators and links to project documentation
  * Introduced comprehensive project planning documentation detailing initiative scope, technical approach, and acceptance criteria
  * Updated project manifest configuration to reflect all newly added documentation files in tracking systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->