### PR TITLE
docs(projects): mark P01 complete

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -22,7 +22,7 @@ file by hand — see Conventions.
 
 | ID  | St    | Project                                                                 |
 |-----|-------|------------------------------------------------------------------------|
-| P01 | `[~]` | [Init app-name rebrand robustness](projects/P01-init-rebrand-robustness.md) — per-field drift coverage (B) + derive non-contract internals (C) |
+| P01 | `[x]` | [Init app-name rebrand robustness](projects/P01-init-rebrand-robustness.md) — per-field drift coverage (B) + derive non-contract internals (C) |
 
 ## Conventions
 

--- a/projects/P01-init-rebrand-robustness.md
+++ b/projects/P01-init-rebrand-robustness.md
@@ -1,6 +1,6 @@
 # P01 — Init app-name rebrand robustness
 
-- **Status:** `[~]` in progress — B + C implemented, PR open
+- **Status:** `[x]` completed — B + C merged (#389)
 - **Captured:** 2026-06-10
 - **Scope:** init rebrand system (`init/`), CLI internals (`src/py_launch_blueprint/`)
 
@@ -84,8 +84,8 @@ engine*, not name derivation.
       from `APP_NAME` (the owner-marker trap is gone; the one remaining uppercase
       token is the user-facing `*_LOG_FILE` env var named in a docstring).
 - [x] User-facing env-var literals unchanged and still greppable.
-- [ ] Full rebrand integration still reports `no-identity-leak: ok` (pending the
-      CI integration run on this PR).
+- [x] Full rebrand integration reports `no-identity-leak: ok` (CI-confirmed:
+      the clone_reinit / integration-ok jobs passed on #389).
 
 ## References
 


### PR DESCRIPTION
## What

Bookkeeping close-out for **P01 — Init app-name rebrand robustness**, whose implementation (B + C) merged in #389.

- `PROJECTS.md`: P01 `[~]` → `[x]` (completed)
- `projects/P01-…md`: status line → completed; tick the final acceptance criterion (**full rebrand `no-identity-leak: ok`**), which is now CI-confirmed — the `clone_reinit` / `integration-ok` jobs passed on #389.

Docs-only; no identity literals changed, so manifest coverage/counts are untouched (`manifest-drift: ok`, P01-file `app_name`/`app_name_upper` counts unchanged vs `discover.py`).

https://claude.ai/code/session_01XRniMePWXYykS8xN1Yrwbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRniMePWXYykS8xN1Yrwbr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Marked project P01 (initialization, rebranding, and robustness efforts) as completed.
  * Confirmed CI integration results for the full rebrand integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->