### PR TITLE
fix(test): guard conftest _git() against running outside the temp sandbox

### DIFF
--- a/init/tests/conftest.py
+++ b/init/tests/conftest.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -43,6 +44,18 @@ from common import MODES  # noqa: E402 — SSOT; re-exported for legacy imports
 
 def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess:
     """Run git with a sandboxed identity (no global config side-effects)."""
+    # Safety rail: these fixtures `git init`/`git commit` under a "Test Fixture"
+    # identity. If `cwd` were ever misdirected at the live repo, that commit
+    # would land on the real project — the root cause of the 152-file-wipe
+    # incident. Refuse to run anywhere but the system temp dir. `.resolve()` on
+    # both sides normalizes macOS `/var/folders` vs `/private/var/folders`.
+    tmp_root = Path(tempfile.gettempdir()).resolve()
+    resolved_cwd = Path(cwd).resolve()
+    if not resolved_cwd.is_relative_to(tmp_root):
+        raise RuntimeError(
+            f"refusing to run sandboxed _git outside the system temp dir: "
+            f"cwd={resolved_cwd} is not under {tmp_root}"
+        )
     env_args = [
         "-c",
         "user.email=test@example.com",

--- a/init/tests/test_conftest_guard.py
+++ b/init/tests/test_conftest_guard.py
@@ -1,0 +1,25 @@
+"""Safety rail for the fixture git helper (``conftest._git``).
+
+The init fixtures run real ``git init`` / ``git commit`` (identity
+``Test Fixture``) inside a temp sandbox. If ``cwd`` were ever misdirected at the
+live repo, that commit would land on the real project — the root cause of the
+152-file-wipe incident (a phantom ``initial commit (fixture)`` that wiped the
+repo, later reverted in #366). ``_git`` refuses to run outside the system temp
+dir; this verifies the rail fires on the live repo and stays out of the way for
+a genuine sandbox.
+"""
+
+from __future__ import annotations
+
+import pytest
+from conftest import LIVE_BLUEPRINT, _git
+
+
+def test_git_refuses_to_run_at_the_live_repo_root() -> None:
+    with pytest.raises(RuntimeError, match="refusing to run sandboxed _git"):
+        _git("status", cwd=LIVE_BLUEPRINT)
+
+
+def test_git_runs_in_a_temp_sandbox(tmp_path) -> None:
+    # A real temp sandbox is allowed: initializing a throwaway repo succeeds.
+    assert _git("init", "-q", cwd=tmp_path).returncode == 0


### PR DESCRIPTION
## What

Re-applies the valuable intent of the closed **#371** — a safety rail on the fixture git helper — fresh against the current `init/tests/conftest.py`. (The original #371 couldn't be merged: its branch carried the 152-file wipe itself.)

## Re-evaluated: the problem is still real
`conftest._git(*args, cwd)` runs real `git` with `check=True` at whatever `cwd` it's handed — including `_git("commit", "-q", "-m", "initial commit (fixture)", cwd=proj)`, the **exact** "initial commit (fixture)" that caused the **152-file-wipe incident** (reverted in #366, recorded in 2.0.0's changelog). On current `main` there is **no guard** that `cwd` is actually a temp sandbox, so a misdirected `cwd` would still commit the fixture's wiped state onto the real repo.

## Fix
`_git()` now refuses to run unless the resolved `cwd` is under `tempfile.gettempdir()`, raising `RuntimeError` otherwise — a misdirected `cwd` fails loudly instead of corrupting the repo. `.resolve()` on both sides normalizes macOS `/var/folders` vs `/private/var/folders` (Linux `/tmp` is uniform).

`init/tests/test_conftest_guard.py`:
- the rail **fires** when `cwd` is the live repo root;
- it **stays out of the way** for a genuine temp sandbox (`git init` succeeds).

## Validation
- new guard test: 2 passed
- full init suite: **81 passed** — every fixture (which runs `_git` under `tmp_path`) still works, confirming the guard doesn't break legitimate use
- ruff / format clean
- `init/tests/` is bootstrap tooling (excluded from the manifest), so no manifest/drift impact

https://claude.ai/code/session_01XRniMePWXYykS8xN1Yrwbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRniMePWXYykS8xN1Yrwbr)_