### PR TITLE
refactor(justfile): remove legacy pip recipes and go toolchain dependency

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -98,8 +98,7 @@ check-deps:
     if ! command -v just >/dev/null 2>&1; then echo "{{YELLOW}}just is not installed{{NC}}\n RUN {{BLUE}}make install-just{{NC}}"; exit 1; fi
     if ! command -v lefthook >/dev/null 2>&1; then echo "{{YELLOW}}WARNING: lefthook is not installed{{NC}}\n RUN {{BLUE}}scripts/install-lefthook.sh{{NC}}"; fi
     if ! command -v taplo >/dev/null 2>&1; then echo "{{YELLOW}}Taplo is not installed{{NC}}\n RUN {{BLUE}}just install-taplo{{NC}}"; exit 1; fi
-    if ! command -v go >/dev/null 2>&1; then echo "{{YELLOW}}go is not installed{{NC}}\n RUN {{BLUE}}make install-go{{NC}}"; exit 1; fi
-    if ! command -v yamlfmt >/dev/null 2>&1; then echo "{{YELLOW}}yamlfmt is not installed{{NC}}\n RUN {{BLUE}}make install-yamlfmt{{NC}}"; exit 1; fi
+    if ! command -v yamlfmt >/dev/null 2>&1; then echo "{{YELLOW}}yamlfmt is not installed{{NC}}\n RUN {{BLUE}}just install-yamlfmt{{NC}}"; exit 1; fi
     echo "All required tools are installed"
 
 alias c := check-deps
@@ -461,47 +460,6 @@ install-gitleaks:
 check-gitleaks mode="full":
     bash scripts/check-gitleaks.sh {{mode}}
 
-# Alternative commands when virtual environment is activated:
-# These commands can be used after running 'source .venv/bin/activate'
-
-# Setup virtual environment
-[group('legacy')]
-@setup-venv:
-    python3 -m venv .venv
-    echo "Note: After setup, activate the virtual environment with:"
-    echo "  source .venv/bin/activate  # On Unix/macOS"
-    echo "  .venv\Scripts\activate  # On Windows"
-
-# Install in development mode
-[group('legacy')]
-@install-dev-pip:
-    pip install --editable ".[dev]"
-
-# Format code (includes ruff format and import sorting)
-[group('legacy')]
-@format-pip:
-    echo "Running linter..."
-    echo "  ruff"
-    ruff format {{py_package_name}}/
-
-# Run linter (code style and quality checks)
-[group('legacy')]
-@lint-pip:
-    ruff check {{py_package_name}}/
-    ruff check --select I --fix {{py_package_name}}/
-
-# Run type checker
-[group('legacy')]
-@typecheck-pip:
-    echo "Running type checker..."
-    echo "  ty"
-    ty check {{py_package_path}}/
-
-# Run tests
-[group('legacy')]
-@test-pip *options:
-    pytest {{options}}
-
 # Create a test repository from a PR
 [group('workflow')]
 [confirm("Are you sure you want to create a new repository from a PR?")]
@@ -706,11 +664,6 @@ clean-pr-to-testrepo new_repo_name="test-actions-repo": _guard
         git checkout main
     fi
 
-# Change working directory example
-[working-directory: 'bar']
-@_foo:
-    echo "example"
-
 [group('dev'), group('quick start')]
 @dev:
     just format
@@ -722,45 +675,49 @@ clean-pr-to-testrepo new_repo_name="test-actions-repo": _guard
 # Alias for dev (full developer cycle: format → lint → test → build)
 alias cycle := dev
 
-# Install Go
+# Install yamlfmt from upstream pre-built binary (no Go toolchain needed —
+# same approach as install-taplo). Detects OS + arch and pulls the matching
+# release asset from https://github.com/google/yamlfmt/releases.
+# Falls back to `go install` if the platform isn't covered.
+#
+# Uses a shebang body so bash interprets $(...) and ${...} directly — Just's
+# template engine would otherwise mangle them.
 [group('setup'), group('install')]
-@install-go:
-    if ! command -v go >/dev/null 2>&1; then \
-        echo "❗ Go is not installed."; \
-        echo "🔧 Installing Go..."; \
-        OS=$(uname); \
-        if [ "$$OS" = "Darwin" ]; then \
-            brew install go >/dev/null 2>&1; \
-        elif [ "$$OS" = "Linux" ]; then \
-            sudo apt update -qq && sudo apt install -y golang-go >/dev/null 2>&1; \
-        else \
-            echo "⚠️ Please install Go manually: https://go.dev/dl/"; \
-            exit 1; \
-        fi; \
-        if command -v go >/dev/null 2>&1; then \
-            echo "✅ Go installation complete."; \
-            echo "⚠️ Please update your PATH."; \
-        else \
-            echo "❌ Go installation failed. Please install manually."; \
-            exit 1; \
-        fi; \
-    else \
-        echo "✅ Go is already installed."; \
+install-yamlfmt:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if command -v yamlfmt >/dev/null 2>&1; then
+        echo -e "{{YELLOW}}yamlfmt is already installed{{NC}}"
+        exit 0
     fi
-
-# Install yamlfmt
-[group('setup'), group('install')]
-@install-yamlfmt:
-    if ! command -v go >/dev/null 2>&1; then \
-        echo "❌ Go is not installed. Run: just install-go"; \
-        exit 1; \
-    fi; \
-    if command -v yamlfmt >/dev/null 2>&1; then \
-        echo "✅ yamlfmt is already installed."; \
-    else \
-        echo "📦 Installing yamlfmt..."; \
-        go install github.com/google/yamlfmt/cmd/yamlfmt@latest; \
-        echo "✅ yamlfmt installed!"; \
+    VERSION=0.17.2
+    case "$(uname -s)" in
+        Linux*)  os=Linux ;;
+        Darwin*) os=Darwin ;;
+        *)       os= ;;
+    esac
+    case "$(uname -m)" in
+        x86_64)        arch=x86_64 ;;
+        arm64|aarch64) arch=arm64 ;;
+        *)             arch= ;;
+    esac
+    if [ -z "$os" ] || [ -z "$arch" ]; then
+        echo -e "{{YELLOW}}No pre-built binary for $(uname -s)/$(uname -m); using go install{{NC}}"
+        go install github.com/google/yamlfmt/cmd/yamlfmt@v${VERSION} \
+            || { echo -e "{{RED}}Failed to install yamlfmt.{{NC}} Install Go first: https://go.dev/dl/" >&2; exit 1; }
+        exit 0
+    fi
+    INSTALL_DIR="$HOME/.local/bin"
+    mkdir -p "$INSTALL_DIR"
+    URL="https://github.com/google/yamlfmt/releases/download/v${VERSION}/yamlfmt_${VERSION}_${os}_${arch}.tar.gz"
+    echo -e "{{BLUE}}Downloading $URL{{NC}}"
+    if curl -fsSL "$URL" | tar -xz -C "$INSTALL_DIR" yamlfmt && chmod +x "$INSTALL_DIR/yamlfmt"; then
+        echo -e "{{GREEN}}✓ yamlfmt ${VERSION} installed to $INSTALL_DIR/yamlfmt{{NC}}"
+        command -v yamlfmt >/dev/null 2>&1 \
+            || echo -e "{{YELLOW}}Note: add $INSTALL_DIR to your PATH to use yamlfmt{{NC}}"
+    else
+        echo -e "{{RED}}Failed to download pre-built yamlfmt; falling back to go install{{NC}}" >&2
+        go install github.com/google/yamlfmt/cmd/yamlfmt@v${VERSION}
     fi
 
 # YAML formatting and validation with yamlfmt

--- a/docs/source/reference/cli_reference.md
+++ b/docs/source/reference/cli_reference.md
@@ -81,14 +81,6 @@ Install the package in editable mode with dev dependencies.
 just install-dev
 ```
 
-### `install-dev-pip`
-Install in development mode using pip.
-
-#### Usage
-```bash
-just install-dev-pip
-```
-
 ---
 
 ## 4. Documentation Management
@@ -203,42 +195,3 @@ Clean up temporary files and caches.
 ```bash
 just clean
 ```
-
----
-
-## 8. Alternative Pip Commands
-
-### `format-pip`
-Format code using pip.
-
-#### Usage
-```bash
-just format-pip
-```
-
-### `lint-pip`
-Run linter using pip.
-
-#### Usage
-```bash
-just lint-pip
-```
-
-### `typecheck-pip`
-Run type checker using pip.
-
-#### Usage
-```bash
-just typecheck-pip
-```
-
-### `test-pip`
-Run tests using pip.
-
-#### Usage
-```bash
-just test-pip [OPTIONS]
-```
-
-#### Options
-- `options`: Additional pytest options.

--- a/docs/source/tools/justfiles.md
+++ b/docs/source/tools/justfiles.md
@@ -52,15 +52,6 @@ just build
 just install-dev
 ```
 
-When your virtual environment is activated, you can also use direct commands without uvx:
-
-```bash
-just format-pip   # Run formatter directly
-just lint-pip     # Run linter directly
-just typecheck-pip # Run type checker directly
-just test-pip     # Run tests directly with pytest
-```
-
-The Justfile standardizes common development tasks and provides a consistent interface for both uvx and direct command execution.
+The Justfile standardizes common development tasks and provides a consistent interface for running them.
 
 For a full list of available commands, refer to [this guide](../reference/cli_reference.md).

--- a/docs/source/tools/yaml_lint.md
+++ b/docs/source/tools/yaml_lint.md
@@ -19,14 +19,9 @@ Our project uses YAML files extensively for configuration, GitHub Actions workfl
 ## ⚙️ Getting Started
 
 ### Prerequisites
-Install Go and yamlfmt:
+Install yamlfmt (downloads the pre-built binary; no Go toolchain needed):
 ```bash
-# Install Go (if not already installed)
-just install-go
-
-# Install yamlfmt
 just install-yamlfmt
-
 ```
 
 ---


### PR DESCRIPTION
## SIMP-01 — purge dead/legacy Justfile recipes

First of a series of single-purpose simplification PRs. Net: **−104 lines**, one fewer mandatory toolchain (Go), zero behavior change for the uv-based workflow.

### What changed

**Justfile**
- Deleted the legacy pip-based recipe set: `setup-venv`, `install-dev-pip`, `format-pip`, `lint-pip`, `typecheck-pip`, `test-pip`. uv is the mandated package manager everywhere else (CLAUDE.md, AGENTS.md, ADRs); the parallel pip path was a second official-looking way to do everything and the recipes referenced the pre-src-layout package path.
- Deleted `_foo` — a literal "working-directory example" demo recipe.
- Deleted `install-go` and rewrote `install-yamlfmt` to download the upstream pre-built binary (same approach as `install-taplo`, ~1s instead of installing a Go toolchain), with a `go install` fallback for uncovered platforms.
- `check-deps`: dropped the hard `go` requirement and fixed broken pointers — it told users to run `make install-go` / `make install-yamlfmt`, but neither is a make target (`install-yamlfmt` is a just recipe). Onboarding no longer requires Go just to format YAML.

**Docs**
- `docs/source/reference/cli_reference.md` — removed the `install-dev-pip` entry and the whole "Alternative Pip Commands" section.
- `docs/source/tools/justfiles.md` — removed the pip-recipe usage block and the stale "uvx vs direct execution" framing.
- `docs/source/tools/yaml_lint.md` — prerequisites no longer mention installing Go.

### Verification

- `just --list` parses; `just check` passes end-to-end (lint, typecheck, full test suite, yaml, spelling, editorconfig)
- Main suite: **104 passed**; init suite: **81 passed**
- Init-system integrity: `check_guard_wiring`, `check_manifest_drift`, `check_path_filter` all pass (Justfile identity vars and `_guard` wiring untouched)
- Blueprint-guard Check 3 simulated locally (temp copy of `Justfile` + `init/`): Tier-1 banner silent on `--list`, fires on recipe run
- `just install-yamlfmt` exercised live on linux/x86_64 — downloads v0.17.2 and installs to `~/.local/bin`; `just check-deps` then passes **without Go installed**
- Lefthook pre-commit (gitleaks, codespell, editorconfig-checker, ruff, commitlint) and pre-push (bandit, gitleaks range, init checks + tests) hooks all passed un-bypassed
- Repo-wide grep confirms no remaining references to any deleted recipe

https://claude.ai/code/session_01SMySE2CVBD3nFPLRZLC7vu

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMySE2CVBD3nFPLRZLC7vu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed legacy virtualenv and pip-based development setup recipes
  * Enhanced yamlfmt installation to prioritize prebuilt binaries with automatic fallback to alternative installation method

* **Documentation**
  * Simplified installation prerequisites and development setup guidance
  * Updated tooling documentation to reflect current standardization approach

<!-- end of auto-generated comment: release notes by coderabbit.ai -->