### PR TITLE
feat(env): add mise and flox as first-class dev environments

### DIFF
--- a/.flox/.gitattributes
+++ b/.flox/.gitattributes
@@ -1,0 +1,1 @@
+env/manifest.lock linguist-generated=true linguist-language=JSON

--- a/.flox/.gitignore
+++ b/.flox/.gitignore
@@ -1,0 +1,5 @@
+run/
+cache/
+lib/
+log/
+!env/

--- a/.flox/env.json
+++ b/.flox/env.json
@@ -1,0 +1,4 @@
+{
+  "name": "py-launch-blueprint",
+  "version": 1
+}

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -1,0 +1,25 @@
+# flox env — one of the project's three first-class dev environments, alongside
+# the native per-tool installs (Justfile `install-*` recipes) and the mise
+# toolchain (mise.toml). All three provision the SAME 10-tool set; keep them in
+# sync when adding or removing a tool.
+#
+# Intentionally NOT installed here: yamllint, codespell, bandit,
+# editorconfig-checker (invoked via `uvx`), commitlint (invoked via
+# `bunx --bun @commitlint/cli`; see the shim note in lefthook.yml), and
+# ty/pytest (project dev deps, provided by `uv run`).
+schema-version = "1.12.0"
+
+[install]
+python.pkg-path = "python312"
+uv.pkg-path = "uv"
+ruff.pkg-path = "ruff"
+taplo.pkg-path = "taplo"
+gitleaks.pkg-path = "gitleaks"
+just.pkg-path = "just"
+bun.pkg-path = "bun"
+gh.pkg-path = "gh"
+lefthook.pkg-path = "lefthook"
+gnumake.pkg-path = "gnumake"
+
+[options]
+systems = ["aarch64-darwin", "x86_64-linux", "aarch64-linux", "x86_64-darwin"]

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -1,7 +1,8 @@
 # flox env — one of the project's three first-class dev environments, alongside
 # the native per-tool installs (Justfile `install-*` recipes) and the mise
 # toolchain (mise.toml). All three provision the SAME 10-tool set; keep them in
-# sync when adding or removing a tool.
+# sync when adding or removing a tool. Decision record:
+# docs/adr/0005-mise-flox-first-class-toolchains.md.
 #
 # Intentionally NOT installed here: yamllint, codespell, bandit,
 # editorconfig-checker (invoked via `uvx`), commitlint (invoked via

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,9 @@ them):
 ## Developer Environment
 - Python: 3.12+ required (per ITM-033)
 - Package manager: `uv` (dev environment), `bun` (commitlint deps; per ADR-04)
-- Toolchain provisioning — three first-class options, all declaring the SAME
-  10-tool set (python, uv, ruff, taplo, gitleaks, just, bun, gh, lefthook,
-  make); keep them in sync when adding/removing a tool:
+- Toolchain provisioning (per ADR 0005) — three first-class options, all
+  declaring the SAME 10-tool set (python, uv, ruff, taplo, gitleaks, just, bun,
+  gh, lefthook, make); keep them in sync when adding/removing a tool:
   1. Native installs (Justfile `install-*` recipes)
   2. `mise install` (root `mise.toml`)
   3. `flox activate` (root `.flox/`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,16 @@ them):
 ## Developer Environment
 - Python: 3.12+ required (per ITM-033)
 - Package manager: `uv` (dev environment), `bun` (commitlint deps; per ADR-04)
+- Toolchain provisioning — three first-class options, all declaring the SAME
+  10-tool set (python, uv, ruff, taplo, gitleaks, just, bun, gh, lefthook,
+  make); keep them in sync when adding/removing a tool:
+  1. Native installs (Justfile `install-*` recipes)
+  2. `mise install` (root `mise.toml`)
+  3. `flox activate` (root `.flox/`)
+- Deliberately NOT in `mise.toml`/`.flox`: yamllint, codespell, bandit,
+  editorconfig-checker (run via `uvx`) and commitlint (run via
+  `bunx --bun @commitlint/cli`) — uv/bun fetch them on demand, and a mise
+  `commitlint` shim shadows bun's PATH fallback (see note in lefthook.yml)
 - Hook manager: `lefthook` (per ADR-01)
 - Build backend: `uv_build` with static `[project] version` (per ADR-06)
 - Releases: `release-please` opens version PR; tag triggers OIDC trusted publish (per ADR-05/07)

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ CHECK := $(GREEN)✓$(NC)
 CROSS := $(RED)✗$(NC)
 DASH := $(GRAY)-$(NC)
 
-.PHONY: all check hook-check install-uv install-just set-path help install-just-force install-uv-force
+.PHONY: all check hook-check install-uv install-just install-flox set-path help install-just-force install-uv-force
 
 all: help
 
@@ -173,6 +173,26 @@ install-uv-force: ## Install uv and add it to PATH
 		echo -e "$(CHECK) PATH already contains $${UV_INSTALL_PATH}"; \
 	fi
 	@echo "Please run 'source ~/.zshenv' or open a new terminal to update your PATH if changes were made."
+
+# Flox is OPTIONAL — one of the three first-class toolchain provisioners
+# (native installs / mise / flox; see docs/adr/0005). Nothing in the project
+# requires it; `flox activate` simply provisions the same 10-tool set declared
+# in .flox/env/manifest.toml. Installation is platform-specific and may need
+# sudo, so this target prints the commands rather than running them.
+install-flox: ## (Optional) Print flox install instructions (toolchain provisioner; see docs/adr/0005)
+	@echo "flox is OPTIONAL — it provisions the dev toolchain declared in .flox/ (see docs/adr/0005)."
+	@echo ""
+	@echo "macOS (Homebrew):"
+	@echo -e "  ${CYAN}brew install flox${NC}"
+	@echo ""
+	@echo "Linux (Debian/Ubuntu — download the .deb, then):"
+	@echo -e "  ${CYAN}sudo apt install ./flox.x86_64-linux.deb${NC}"
+	@echo "Linux (Fedora/RHEL — download the .rpm, then):"
+	@echo -e "  ${CYAN}sudo dnf install ./flox.x86_64-linux.rpm${NC}"
+	@echo ""
+	@echo "Downloads and all install options (incl. nix profile): https://flox.dev/docs/install-flox/"
+	@echo ""
+	@echo -e "Then run ${YELLOW}flox activate${NC} from the repo root to enter the environment."
 
 set-path: ## Add SET_PATH to PATH in .zshenv if not already present
 	@if [ -z "$(SET_PATH)" ]; then \

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Teams and professionals needing maintainable, type-safe Python projects followin
 
 - **Bootstrap dependency check and install with `make`**: Execute common development tasks with simple commands, standardizing workflows across team members.
 
+- **Optional one-command toolchains with [`mise`](https://mise.jdx.dev/) or [`flox`](https://flox.dev/)**: `mise install` (root `mise.toml`) or `flox activate` (root `.flox/`) provisions the same 10-tool set as the native installers — pick whichever fits your machine; see [ADR 0005](docs/adr/0005-mise-flox-first-class-toolchains.md).
+
 - **Command running with `just`**: Define and run project-specific commands with a modern Make alternative, simplifying complex operations with clear syntax.
 
 - **Linting with `ruff`**: Catch errors and enforce code style at lightning speed (10-100x faster than traditional linters), reducing waiting time and improving developer productivity.

--- a/docs/adr/0005-mise-flox-first-class-toolchains.md
+++ b/docs/adr/0005-mise-flox-first-class-toolchains.md
@@ -1,0 +1,91 @@
+# 0005. mise and flox are first-class toolchain provisioners (lean 10-tool set)
+
+- **Status:** Accepted
+- **Date:** 2026-06-12
+- **Deciders:** maintainer
+- **Related:** historical ADR-04 (commitlint via bun); the shim note in
+  `lefthook.yml`; the CI provisioning benchmark preserved on branch
+  `experiment/flox-ci-timing-perf-analysis` (removed from main in PR #386)
+
+## Context
+
+The dev toolchain was provisioned only via native per-tool installs (Makefile
+bootstrap + Justfile `install-*` recipes). A CI benchmark experiment built
+[mise](https://mise.jdx.dev/) and [flox](https://flox.dev/) manifests to compare
+provisioners; those manifests declared a 15-tool set so every linter could run
+as a bare binary under `mise exec` / `flox activate` — the experiment's premise,
+not the repo's real workflow.
+
+Auditing that set against actual usage surfaced two problems:
+
+1. **Duplicate version sources.** yamllint, codespell, bandit, and
+   editorconfig-checker are invoked via `uvx`, and commitlint via
+   `bunx --bun @commitlint/cli` (historical ADR-04) — uv/bun fetch them on
+   demand. Declaring them in a provisioner manifest creates a second,
+   independently-drifting source of versions that the hooks never use.
+2. **An active defect.** The mise `commitlint` shim shadowed bun's PATH
+   fallback: on a cold bun cache, `bunx --bun commitlint` resolved to the shim
+   and failed with "No version is set for shim: commitlint". The commit-msg
+   hook had to pin the scoped package name as a workaround (documented in
+   `lefthook.yml`).
+
+## Decision
+
+We will support **three first-class, equivalent toolchain provisioners** and
+keep them in sync:
+
+1. **Native installs** — Makefile bootstrap (`make check`, `install-*`) +
+   Justfile `install-*` recipes (unchanged).
+2. **mise** — root `mise.toml`; provision with `mise install`.
+3. **flox** — root `.flox/`; provision with `flox activate`.
+
+Both manifests declare the **same lean 10-tool set**: python 3.12, uv, ruff,
+taplo, gitleaks, just, bun, gh, lefthook, make. Adding or removing a tool means
+updating all three options.
+
+Deliberately excluded from the manifests:
+
+- **uvx-invoked linters** (yamllint, codespell, bandit, editorconfig-checker)
+  and **bunx-invoked commitlint** — uv/bun remain their single version source.
+  Dropping commitlint also removes the mise shim conflict at its root.
+- **ty and pytest** — project dev dependencies, provided by `uv run`.
+
+Supporting choices:
+
+- The manifests live at the **repo root** so both tools auto-discover them —
+  that is what "first-class" means here. (The experiment intentionally hid its
+  config under `experiment/` to avoid auto-loading.)
+- The Makefile gains an **optional, print-only `install-flox` target**
+  (matching the `install-just`/`install-uv` pattern): flox installation is
+  platform-specific and may need sudo, so we document rather than execute.
+  mise bootstrap is covered by its upstream one-liner, linked from the docs.
+- The flox `manifest.lock` is **not committed yet**; flox generates it on first
+  `flox activate`. Committing it (for fully pinned envs) is left as follow-up.
+
+## Consequences
+
+- Contributors can provision the whole toolchain with one command (`mise
+  install` or `flox activate`) instead of N installers; the native path keeps
+  working for everyone else.
+- Three places now declare the toolchain. The sync rule is recorded in
+  CLAUDE.md and in a header comment in each manifest; there is no automated
+  drift check between them (possible follow-up).
+- The commit-msg hook's pinned `@commitlint/cli` invocation stays — it is
+  correct regardless of provisioner — but the failure mode it guarded against
+  can no longer occur from our own manifests.
+- Anyone with mise installed globally will auto-load `mise.toml` when entering
+  the repo; this is now intended behavior.
+
+## Alternatives considered
+
+- **Keep the experiment's 15-tool manifests** — duplicates uv/bun-managed
+  versions and re-introduces the commitlint shim defect; the extra five tools
+  are never taken from PATH by hooks or CI.
+- **Bless a single provisioner (mise-only or flox-only)** — the benchmark
+  showed no decisive winner, and forcing one tool on contributors contradicts
+  the template's "meet developers where they are" goal.
+- **Devcontainer as the only turnkey env** — already exists, but requires
+  Docker and an editor that supports it; mise/flox work in any shell.
+- **Executing the flox installer from `make install-flox`** — rejected:
+  platform-specific packages plus sudo make a curl-pipe-style force target
+  riskier than the print-only convention used for just/uv.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,6 +23,7 @@ Start from [`template.md`](template.md).
 | [0002](0002-no-secrets-in-config-file.md) | Secrets are never stored in the config file | Accepted |
 | [0003](0003-keep-markdown-output-mode.md) | Keep `markdown` as a third output format (spec deviation) | Accepted |
 | [0004](0004-config-errors-degrade-to-warnings.md) | Invalid config values degrade to warnings, never crashes | Accepted |
+| [0005](0005-mise-flox-first-class-toolchains.md) | mise and flox are first-class toolchain provisioners (lean 10-tool set) | Accepted |
 
 ## Note on historical decisions
 

--- a/docs/source/reference/project_structure.md
+++ b/docs/source/reference/project_structure.md
@@ -44,6 +44,8 @@ py-launch-blueprint/
 │   ├── __init__.py                 # Test package initialization
 │   ├── cli/                        # CLI tests
 │   └── core/                       # Library tests
+├── .flox/                          # Flox environment (optional toolchain provisioner; ADR 0005)
+│   └── env/manifest.toml           # Declares the 10-tool dev set for `flox activate`
 ├── .gitignore                      # Git ignore file
 ├── .pre-commit-config.yaml         # Pre-commit hooks configuration
 ├── .python-version                 # Python version file
@@ -71,6 +73,7 @@ py-launch-blueprint/
 ├── EXAMPLECLI.md                   # Example CLI documentation
 ├── Justfile                        # Just task runner configuration
 ├── Makefile                        # Makefile for building the project
+├── mise.toml                       # mise toolchain (optional provisioner; ADR 0005)
 ├── PULL_REQUEST_TEMPLATE.md        # Pull request template
 ├── src/py_launch_blueprint/        # Source code for the project
 │   ├── __init__.py                 # Package initialization

--- a/docs/source/tasks/setting_up_development.md
+++ b/docs/source/tasks/setting_up_development.md
@@ -5,6 +5,28 @@ Run the following command to check if the base dependencies are installed.
 make check
 ```
 
+### (Optional) Provision the whole toolchain with mise or flox
+
+Instead of installing each tool natively, you can provision the project's full
+10-tool set (python, uv, ruff, taplo, gitleaks, just, bun, gh, lefthook, make)
+with a single command — both manifests live at the repo root and are kept in
+sync with the native installers (see
+[ADR 0005](https://github.com/smorinlabs/py-launch-blueprint/blob/main/docs/adr/0005-mise-flox-first-class-toolchains.md)):
+
+```bash
+# Option A: mise (https://mise.jdx.dev/) — reads mise.toml
+curl https://mise.run | sh   # install mise itself, then:
+mise install
+
+# Option B: flox (https://flox.dev/) — reads .flox/
+make install-flox            # prints platform-specific install instructions
+flox activate
+```
+
+Note: yamllint, codespell, bandit, editorconfig-checker, and commitlint are
+deliberately not in these manifests — they are fetched on demand via
+`uvx`/`bunx` by the git hooks and Justfile recipes.
+
 # Setup Development Environment
 
 Project requires Python 3.12+ (which is also specified inside [.python-version](https://github.com/smorinlabs/py-launch-blueprint/blob/main/.python-version) file)

--- a/init/manifest.toml
+++ b/init/manifest.toml
@@ -268,6 +268,7 @@ field = "repo_name"
 current = ["py-launch-blueprint"]
 files = [
   ".devcontainer/devcontainer.json",              # 1x
+  ".flox/env.json",                               # 1x
   ".github/CONTRIBUTING.md",                      # 1x
   ".github/ISSUE_TEMPLATE/config.yml",            # 1x
   ".github/codeql/codeql-config.yml",             # 1x

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,8 @@
 # mise toolchain — one of the project's three first-class dev environments,
 # alongside the native per-tool installs (Justfile `install-*` recipes) and the
 # flox env (.flox/env/manifest.toml). All three provision the SAME 10-tool set;
-# keep them in sync when adding or removing a tool.
+# keep them in sync when adding or removing a tool. Decision record:
+# docs/adr/0005-mise-flox-first-class-toolchains.md.
 #
 # Intentionally NOT declared here:
 #   * yamllint, codespell, bandit, editorconfig-checker — invoked via `uvx`

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,23 @@
+# mise toolchain — one of the project's three first-class dev environments,
+# alongside the native per-tool installs (Justfile `install-*` recipes) and the
+# flox env (.flox/env/manifest.toml). All three provision the SAME 10-tool set;
+# keep them in sync when adding or removing a tool.
+#
+# Intentionally NOT declared here:
+#   * yamllint, codespell, bandit, editorconfig-checker — invoked via `uvx`
+#     (lefthook.yml / Justfile), fetched on demand by uv.
+#   * commitlint — invoked via `bunx --bun @commitlint/cli` (ADR-04); a mise
+#     shim named `commitlint` shadows bun's PATH fallback and breaks the
+#     commit-msg hook on a cold bun cache (see the note in lefthook.yml).
+#   * ty, pytest — project dev deps, provided by `uv run`.
+[tools]
+python = "3.12"
+uv = "latest"
+ruff = "latest"
+taplo = "latest"
+gitleaks = "latest"
+just = "latest"
+bun = "latest"
+gh = "latest"
+lefthook = "latest"
+make = "latest"


### PR DESCRIPTION
## Summary

Promotes the toolchain configs from the CI benchmark experiment (removed from `main` in #386, preserved on `experiment/flox-ci-timing-perf-analysis`) to first-class dev environments alongside the native Justfile installs:

- **`mise.toml`** (repo root) — `mise install` provisions the toolchain
- **`.flox/`** (repo root) — `flox activate` provisions the same toolchain
- **`docs/adr/0005-mise-flox-first-class-toolchains.md`** — records all of these decisions (indexed in the ADR README)
- **`Makefile`** — optional, print-only `install-flox` target following the `install-just`/`install-uv` pattern (flox install is platform-specific and may need sudo, so it documents rather than executes)
- **Docs** — provisioning options surfaced in README (feature list), `docs/source/tasks/setting_up_development.md` (optional mise/flox setup section), `docs/source/reference/project_structure.md` (root tree entries), manifest header comments, and CLAUDE.md (three-way provisioning contract + keep-in-sync rule)

## Lean 10-tool set

Both manifests declare the same set: python 3.12, uv, ruff, taplo, gitleaks, just, bun, gh, lefthook, make.

Dropped relative to the experiment's 15-tool manifests:

| Tool | Why removed |
|---|---|
| yamllint, codespell, bandit, editorconfig-checker | Invoked via `uvx` in lefthook.yml/Justfile — uv fetches them on demand; declaring them in mise/flox duplicates the version source |
| commitlint | Invoked via `bunx --bun @commitlint/cli` (ADR-04). The mise `commitlint` shim shadowed bun's PATH fallback and broke the commit-msg hook on a cold bun cache (documented workaround in lefthook.yml) — this removes the conflict at the source |

`ty`/`pytest` remain project dev deps via `uv run`, as before.

## Init-system integrity

`.flox/env.json` carries the `py-launch-blueprint` identity value, so it's registered under `repo_name` in `init/manifest.toml`. Drift check and `init/tests/` (81 passed) are green; taplo/editorconfig/codespell clean.

## Notes

- The flox `manifest.lock` is not committed — flox generates it on first `flox activate` (flox isn't available in this environment to pre-generate it). If you'd like it pinned, run `flox activate` locally once and commit the lock. Recorded as follow-up in ADR 0005.

https://claude.ai/code/session_01CHNbASF7jCidME7bdBzhfB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional one-command toolchain provisioning via `mise activate` or `flox activate` for streamlined development environment setup.

* **Documentation**
  * Documented the supported toolchain provisioning options and synchronized development tools.
  * Updated project structure and setup guides with mise and flox instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->