### PR TITLE
docs(env): address copilot review on #403 — ignore flox lock, broaden native-install wording

### DIFF
--- a/.flox/.gitignore
+++ b/.flox/.gitignore
@@ -3,3 +3,6 @@ cache/
 lib/
 log/
 !env/
+# Generated on first `flox activate`; deliberately not committed yet (ADR 0005
+# follow-up). Remove this line if/when the lock is pinned in the repo.
+env/manifest.lock

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -1,7 +1,7 @@
 # flox env — one of the project's three first-class dev environments, alongside
-# the native per-tool installs (Justfile `install-*` recipes) and the mise
-# toolchain (mise.toml). All three provision the SAME 10-tool set; keep them in
-# sync when adding or removing a tool. Decision record:
+# the native per-tool installs (Makefile + Justfile `install-*` targets,
+# scripts/install-*.sh) and the mise toolchain (mise.toml). All three provision
+# the SAME 10-tool set; keep them in sync when adding or removing a tool. Decision record:
 # docs/adr/0005-mise-flox-first-class-toolchains.md.
 #
 # Intentionally NOT installed here: yamllint, codespell, bandit,

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -1,8 +1,8 @@
 # flox env — one of the project's three first-class dev environments, alongside
 # the native per-tool installs (Makefile + Justfile `install-*` targets,
 # scripts/install-*.sh) and the mise toolchain (mise.toml). All three provision
-# the SAME 10-tool set; keep them in sync when adding or removing a tool. Decision record:
-# docs/adr/0005-mise-flox-first-class-toolchains.md.
+# the SAME 10-tool set; keep them in sync when adding or removing a tool.
+# Decision record: docs/adr/0005-mise-flox-first-class-toolchains.md.
 #
 # Intentionally NOT installed here: yamllint, codespell, bandit,
 # editorconfig-checker (invoked via `uvx`), commitlint (invoked via

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ them):
 - Toolchain provisioning (per ADR 0005) — three first-class options, all
   declaring the SAME 10-tool set (python, uv, ruff, taplo, gitleaks, just, bun,
   gh, lefthook, make); keep them in sync when adding/removing a tool:
-  1. Native installs (Justfile `install-*` recipes)
+  1. Native installs (Makefile + Justfile `install-*` targets, `scripts/install-*.sh`)
   2. `mise install` (root `mise.toml`)
   3. `flox activate` (root `.flox/`)
 - Deliberately NOT in `mise.toml`/`.flox`: yamllint, codespell, bandit,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,8 @@ them):
 - Toolchain provisioning (per ADR 0005) — three first-class options, all
   declaring the SAME 10-tool set (python, uv, ruff, taplo, gitleaks, just, bun,
   gh, lefthook, make); keep them in sync when adding/removing a tool:
-  1. Native installs (Makefile + Justfile `install-*` targets, `scripts/install-*.sh`)
+  1. Native installs (Makefile + Justfile `install-*` targets,
+     `scripts/install-*.sh`)
   2. `mise install` (root `mise.toml`)
   3. `flox activate` (root `.flox/`)
 - Deliberately NOT in `mise.toml`/`.flox`: yamllint, codespell, bandit,

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,8 @@
 # mise toolchain — one of the project's three first-class dev environments,
-# alongside the native per-tool installs (Justfile `install-*` recipes) and the
-# flox env (.flox/env/manifest.toml). All three provision the SAME 10-tool set;
-# keep them in sync when adding or removing a tool. Decision record:
+# alongside the native per-tool installs (Makefile + Justfile `install-*`
+# targets, scripts/install-*.sh) and the flox env (.flox/env/manifest.toml).
+# All three provision the SAME 10-tool set; keep them in sync when adding or
+# removing a tool. Decision record:
 # docs/adr/0005-mise-flox-first-class-toolchains.md.
 #
 # Intentionally NOT declared here:


### PR DESCRIPTION
## Summary

Follow-up to #403, addressing all three findings from its Copilot review (which landed after the merge):

1. **Ignore the flox lock file** — `.flox/env/manifest.lock` is generated on first `flox activate` and is deliberately not committed yet (ADR 0005 follow-up). Added to `.flox/.gitignore` with a comment saying to remove the line if/when the lock is pinned, so flox users don't see untracked noise or accidentally commit it.
2. **`mise.toml` header** — the native install path is now credited fully (Makefile + Justfile `install-*` targets, `scripts/install-*.sh`) instead of only the Justfile recipes.
3. **`.flox/env/manifest.toml` header** — same wording fix.

Also applied the same wording fix to the matching bullet in CLAUDE.md for consistency.

Checks run: taplo, manifest drift check, init tests (81 passed), lefthook pre-commit/pre-push hooks.

https://claude.ai/code/session_01CHNbASF7jCidME7bdBzhfB

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHNbASF7jCidME7bdBzhfB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ignore the generated environment lock file to avoid committing local build artifacts.
* **Documentation**
  * Clarified toolchain provisioning docs and headers to describe the three installation methods and confirm they provision the same toolset to keep installs in sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->