### PR TITLE
docs(projects): capture P02 repo-simplification (SIMP series)

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -23,6 +23,7 @@ file by hand — see Conventions.
 | ID  | St    | Project                                                                 |
 |-----|-------|------------------------------------------------------------------------|
 | P01 | `[x]` | [Init app-name rebrand robustness](projects/P01-init-rebrand-robustness.md) — per-field drift coverage (B) + derive non-contract internals (C) |
+| P02 | `[~]` | [Repo simplification & organization (SIMP series)](projects/P02-repo-simplification.md) — single-purpose PRs to simplify/consolidate Justfile, docs, setup, tests, workflows, agent configs |
 
 ## Conventions
 

--- a/docs/adr/0014-repo-simplification-batch.md
+++ b/docs/adr/0014-repo-simplification-batch.md
@@ -1,0 +1,109 @@
+# 0014. Repo simplification batch — canonical agent config, skill placement, docs & CI layout (SIMP series)
+
+- **Status:** Accepted
+- **Date:** 2026-06-12
+- **Deciders:** maintainer (interactive), implemented across PRs #401, #402,
+  #405, #407, #409–#413
+- **Related:** `projects/P02-repo-simplification.md` (the tracked initiative
+  with per-item verification analysis); ADR 0005 (toolchain provisioning);
+  the init-system contract (`init/manifest.toml` + `init/ci/*` guards)
+
+## Context
+
+The repo accreted overlapping configuration surfaces: five files of agent
+guidance, duplicated community files, a bootstrap skill no tool could
+discover, half-organized tests, root-level markdown of mixed audiences, and
+five CI workflows that were 80% identical boilerplate. A ranked
+simplification catalogue (SIMP-01..12) was verified item-by-item against the
+init/rebrand machinery before acting; this ADR records the decisions the
+batch settled. Execution model: one verified, single-purpose PR per item.
+
+## Decisions
+
+### 1. AGENTS.md is the single canonical agent config (SIMP-06)
+
+Shared agent guidance lives in **`AGENTS.md`** only. `CLAUDE.md` is a thin
+entrypoint that imports it (`@AGENTS.md`) plus Claude-specific notes.
+Vendor rule files (`.windsurfrules`, `.cursor/rules/`, `.windsurf/rules/`)
+are **deleted** — Cursor, Windsurf, and Codex read AGENTS.md natively.
+
+Why this direction and not the inverse: Claude Code's `@`-import is the
+only *mechanical* cross-file link available; AGENTS.md is plain markdown
+with no import syntax, so content placed only in CLAUDE.md would reach
+other agents via a prose pointer at best. Durable content from the deleted
+files (Justfile editing conventions) moved to
+`docs/source/tools/justfiles.md`.
+
+### 2. The bootstrap skill lives in real discovery paths and never requires `just` (SIMP-11)
+
+`skill/` at the repo root was no tool's discovery path — the skill was
+documentation wearing a skill's clothes. Canonical location is now
+**`.claude/skills/new-python-project/`** (Claude Code project-skill
+discovery; invocable as `/new-python-project`), with an
+**`.agents/skills/new-python-project` symlink** for Codex (its documented
+repo scan path). On Windows checkouts without git symlink support the
+symlink degrades to a text file — accepted; only Codex auto-discovery is
+lost.
+
+The runbook is **universal**: it requires only `gh` + `uv`, invoking
+`init/init.py` / `init/post_init.py` directly (`just` recipes are thin
+wrappers). It *recommends* the toolchain path — `make check`,
+`make install-just` (prints, never runs), `make bootstrap` — but never
+executes machine-modifying installs on the user's behalf.
+
+### 3. Bootstrap dirs are for blueprint-only tooling; fork-facing files must not live there (SIMP-07 corollary)
+
+`init/` (and the skill dir) are pruned by `init --prune` and exempt from
+identity scans. Therefore anything a fork must keep — like `POST_INIT.md`,
+the fork-facing post-init checklist — must NOT live there. This corrected
+the original analysis, which had slated `POST_INIT.md` for `init/`.
+
+### 4. Root markdown placement policy (SIMP-07, SIMP-10)
+
+- **Operational guides** → `docs/` (unpublished, alongside the engineering
+  docs): `POST_INIT.md`, `RELEASE.md`.
+- **Analysis / research artifacts** → `docs/research/` with `NNNN-` naming
+  and an index entry (skill trigger-optimization writeup, init/post-init
+  systems analysis). Files there carrying blueprint identity get manifest
+  coverage rather than exemption.
+- **Product-front docs stay at root**: `EXAMPLECLI.md` keeps its prominent
+  README placement (deliberate; ~49 manifest occurrences made the move
+  high-churn for no gain).
+- **Community files GitHub surfaces natively live in `.github/` as the
+  single source**; the Sphinx copy includes them via MyST `{include}`
+  (`CODE_OF_CONDUCT.md` — the duplicate was byte-identical).
+
+### 5. Test layout mirrors what is being tested (SIMP-08)
+
+`tests/{cli,core,web}` test the shipped package; **`tests/meta/`** tests
+the repo's own machinery (contributor automation, Justfile recipes,
+version consistency). No flat test files at the root besides
+`conftest.py`/`__init__.py`. Root-finding in meta tests uses
+`parents[2]`.
+
+### 6. One lint workflow, jobs keep their check names, path-aware where filters existed (SIMP-09)
+
+The five single-purpose lint workflows (actionlint, bandit, codespell,
+editorconfig-check, yamllint) are jobs of one **`lint.yml`**. Job names
+match the old check contexts exactly, so branch-protection required checks
+survive unchanged. actionlint and yamllint keep their historical path
+filters via a `lint-changes` detection job (per-job `if:`), because
+workflow-level `paths:` cannot be applied per job. A skipped job
+*satisfies* a required status check — strictly better than the old
+filtered-out workflows, which never reported their context at all.
+
+## Consequences
+
+- One file to edit for agent behavior; generated projects update AGENTS.md
+  and nothing else.
+- The bootstrap skill is actually invocable (verified live in a Claude Code
+  session) and usable by gh+uv-only environments.
+- Forks no longer inherit blueprint-only artifacts (skill pruned, as
+  before, now at the new path) but always keep their operational guides.
+- Adding a linter is a six-line job in `lint.yml`, not a new workflow file;
+  docs-only PRs skip actionlint/yamllint without risking a hung required
+  check.
+- Dropped/deferred for the record: SIMP-05 (Makefile replacement —
+  superseded by the two-level setup, ADR'd in the P02 file), SIMP-12
+  (commitlint config merge — the split is load-bearing), SIMP-04 (Justfile
+  module split — breaks four init couplings; in-place reorg only, optional).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,6 +31,7 @@ Start from [`template.md`](template.md).
 | [0010](0010-rich-row-variant-on-result-models.md) | Terminal niceties via a rich-only row variant on result models | Accepted |
 | [0011](0011-windows-native-paths-xdg-overrides.md) | Windows-native default directories; XDG overrides win everywhere | Accepted |
 | [0012](0012-doctor-bundle-redact-at-collection.md) | `doctor --bundle` redacts at collection time, excludes log contents | Accepted |
+| [0014](0014-repo-simplification-batch.md) | Repo simplification batch — canonical agent config, skill placement, docs & CI layout (SIMP series) | Accepted |
 
 ## Note on historical decisions
 

--- a/docs/source/contributing/CODE_OF_CONDUCT.md
+++ b/docs/source/contributing/CODE_OF_CONDUCT.md
@@ -1,24 +1,5 @@
-# **Code of Conduct**
+% Single-sourced from .github/CODE_OF_CONDUCT.md (GitHub surfaces that copy
+% natively). Edit the .github/ file; this page only includes it.
 
-## **Our Pledge**
-We commit to fostering an inclusive, harassment-free community for all, regardless of background or identity.
-
-## **Standards**
-### **Expected Behavior**
-- Show empathy and respect differences.
-- Give and accept constructive feedback.
-- Take responsibility and learn from mistakes.
-
-### **Unacceptable Behavior**
-- Harassment, trolling, or personal attacks.
-- Publishing private information without consent.
-- Any conduct deemed inappropriate in a professional setting.
-
-## **Enforcement**
-Community leaders will enforce this code fairly, with actions including warnings, temporary bans, or permanent removal for repeated or severe violations.
-
-## **Reporting**
-Report violations to [INSERT CONTACT]. Reports will be reviewed confidentially and handled appropriately.
-
-## **Attribution**
-Adapted from the [Contributor Covenant](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html).
+```{include} ../../../.github/CODE_OF_CONDUCT.md
+```

--- a/projects/P02-repo-simplification.md
+++ b/projects/P02-repo-simplification.md
@@ -1,6 +1,6 @@
 # P02 — Repo simplification & organization (SIMP series)
 
-- **Status:** `[~]` in progress — SIMP-01/02/03 merged; SIMP-10 implemented in #407; SIMP-06/07/08/09/11 planned; SIMP-04/05/12 dropped or deferred
+- **Status:** `[~]` in progress — SIMP-01/02/03 merged; SIMP-10 in #407; SIMP-11/06/08/07/09 implemented in PRs #409–#413 (awaiting review/merge); SIMP-04/05/12 dropped or deferred
 - **Captured:** 2026-06-12
 - **Scope:** repo-wide structure & tooling — `Justfile`, `Makefile`, `docs/`,
   `tests/`, `.github/workflows/`, agent-config files, root markdown
@@ -50,11 +50,11 @@ reviewable and revertible.
 | done | SIMP-02 | Fix the broken docs toolchain | Drift fix / consolidation | High | ✅ merged #402 |
 | done | SIMP-03 | Two-level setup (`make bootstrap` + `just setup`) | Consolidation / DX | High | ✅ merged #405 |
 | done | SIMP-10 | Single-source CODE_OF_CONDUCT | DRY | Low-Med | ✅ in #407 |
-| 2 | SIMP-11 | Move `skill/optimization-workspace/` out | Organization | Low-Med | Do — + manifest question |
-| 3 | SIMP-06 | Canonical AGENTS.md; thin vendor rules | DRY / consolidation | Med | Do — CI enforces the risk |
-| 4 | SIMP-08 | Group flat test files | Organization | Med | Do — mechanical |
-| 5 | SIMP-07 | Relocate root markdown | Organization | Med | Do — one scope question |
-| 6 | SIMP-09 | Consolidate single-purpose lint workflows | Consolidation | Med | Do last — one external check |
+| done | SIMP-11 | Relocate skill to `.claude/skills/` + Codex symlink; research moved | Organization | Low-Med | 🔄 PR #409 |
+| done | SIMP-06 | AGENTS.md canonical; CLAUDE.md `@`-imports it; vendor rules deleted | DRY / consolidation | Med | 🔄 PR #410 (stacked on #409) |
+| done | SIMP-08 | Group flat test files (`tests/meta/`, `tests/cli/`) | Organization | Med | 🔄 PR #411 |
+| done | SIMP-07 | `POST_INIT.md` + `RELEASE.md` → `docs/`; analysis → research on #408 | Organization | Med | 🔄 PR #412 (stacked on #410) |
+| done | SIMP-09 | Five lint workflows → one `lint.yml` with path-aware jobs | Consolidation | Med | 🔄 PR #413 (stacked on #406) |
 | 7 (opt) | SIMP-04 | Reorganize the Justfile (in place) | Organization | Med | Defer/optional |
 | — | SIMP-05 | Replace the root Makefile | Simplification | — | **Dropped — superseded by SIMP-03** |
 | — | SIMP-12 | Merge the two commitlint configs | DRY | — | **Dropped — split is load-bearing** |
@@ -62,6 +62,23 @@ reviewable and revertible.
 The logic: items 1–3 touch disjoint files (any order; no rebases), 4–5 are the
 manifest-touching moves in increasing size, 6 waits on a repo-settings check
 only the maintainer can do quickly, and 7 is optional polish.
+
+**Corrections discovered during execution** (amending the analysis above):
+
+- SIMP-11's "manifest `[[remove]]` question" was moot — `init/init.py` already
+  prunes `skill/` on `just init` (forks never shipped it). The skill moved to
+  `.claude/skills/new-python-project/` (real Claude Code discovery) with an
+  `.agents/skills/` symlink for Codex, and was de-just'd (#409).
+- SIMP-07's `POST_INIT.md → init/` destination was wrong: `init/` is prunable,
+  scan-excluded bootstrap tooling, while POST_INIT.md is fork-facing and must
+  survive prune. It went to `docs/` instead (#412); `EXAMPLECLI.md` stays at
+  root per maintainer decision.
+- SIMP-08: all five meta tests (not just `test_justfile.py`) resolved the repo
+  root via `parents[1]`/`parent.parent` — all bumped to `parents[2]` (#411).
+- SIMP-09: per maintainer direction, actionlint/yamllint keep their path-
+  filtered behavior via a `lint-changes` detection job (validated against six
+  diff scenarios); skipped jobs satisfy required checks, which the old
+  filtered-out workflows did not (#413, stacked on #406).
 
 ## Completed work
 

--- a/projects/P02-repo-simplification.md
+++ b/projects/P02-repo-simplification.md
@@ -1,6 +1,6 @@
 # P02 — Repo simplification & organization (SIMP series)
 
-- **Status:** `[~]` in progress — SIMP-01/02/03 merged; SIMP-06/07/08/09/10/11 planned; SIMP-04/05/12 dropped or deferred
+- **Status:** `[~]` in progress — SIMP-01/02/03 merged; SIMP-10 implemented in #407; SIMP-06/07/08/09/11 planned; SIMP-04/05/12 dropped or deferred
 - **Captured:** 2026-06-12
 - **Scope:** repo-wide structure & tooling — `Justfile`, `Makefile`, `docs/`,
   `tests/`, `.github/workflows/`, agent-config files, root markdown
@@ -49,7 +49,7 @@ reviewable and revertible.
 | done | SIMP-01 | Purge dead/legacy Justfile recipes | Dead-code removal | High | ✅ merged #401 |
 | done | SIMP-02 | Fix the broken docs toolchain | Drift fix / consolidation | High | ✅ merged #402 |
 | done | SIMP-03 | Two-level setup (`make bootstrap` + `just setup`) | Consolidation / DX | High | ✅ merged #405 |
-| 1 | SIMP-10 | Single-source CODE_OF_CONDUCT | DRY | Low-Med | Do — files byte-identical |
+| done | SIMP-10 | Single-source CODE_OF_CONDUCT | DRY | Low-Med | ✅ in #407 |
 | 2 | SIMP-11 | Move `skill/optimization-workspace/` out | Organization | Low-Med | Do — + manifest question |
 | 3 | SIMP-06 | Canonical AGENTS.md; thin vendor rules | DRY / consolidation | Med | Do — CI enforces the risk |
 | 4 | SIMP-08 | Group flat test files | Organization | Med | Do — mechanical |
@@ -98,17 +98,16 @@ Makefile didn't run on stock Linux), `just install-dev` silently installing
 zero dev deps (stale `.[dev]` extra), and a stale `bun.lock` (commitlint
 19→21). CLAUDE.md + AGENTS.md document the flow as canonical.
 
+### SIMP-10 — Single-source CODE_OF_CONDUCT (implemented in #407)
+
+`CODE_OF_CONDUCT.md` existed byte-identically in both `.github/` and
+`docs/source/contributing/` (`diff` clean). The Sphinx copy now pulls the
+`.github/` source (which GitHub surfaces natively) via a MyST `{include}`
+wrapper. Verified: docs build succeeds with no new warnings and the rendered
+page contains the CoC content; RTD builds from a full checkout so `.github/`
+is present; neither file is in the init manifest.
+
 ## Planned items
-
-### SIMP-10 — Single-source CODE_OF_CONDUCT (DRY · Low-Med value)
-
-`CODE_OF_CONDUCT.md` exists byte-identically in both `.github/` and
-`docs/source/contributing/` (`diff` clean). Keep `.github/` as the source
-(GitHub surfaces it natively) and have the Sphinx copy pull it in via a MyST
-`{include}`. Verified safe: RTD builds from a full checkout so `.github/` is
-present; neither file is in the init manifest. Only watch-out: Sphinx emits a
-"document outside source directory" warning — harmless unless docs builds turn
-on `-W` (they don't).
 
 ### SIMP-11 — Move `skill/optimization-workspace/` out (Organization · Low-Med)
 

--- a/projects/P02-repo-simplification.md
+++ b/projects/P02-repo-simplification.md
@@ -1,0 +1,215 @@
+# P02 — Repo simplification & organization (SIMP series)
+
+- **Status:** `[~]` in progress — SIMP-01/02/03 merged; SIMP-06/07/08/09/10/11 planned; SIMP-04/05/12 dropped or deferred
+- **Captured:** 2026-06-12
+- **Scope:** repo-wide structure & tooling — `Justfile`, `Makefile`, `docs/`,
+  `tests/`, `.github/workflows/`, agent-config files, root markdown
+
+## Original requirement
+
+Two requests framed this project. The first asked for a ranked catalogue of
+simplification ideas:
+
+> I like to get ideas on ways to simplify, better organize, consolidate this
+> project. Stuff on the files, directory structure, things like that. So
+> looking for ideas, rank each one, making clear what the benefit would be,
+> what it would be, give it an ID, give it the type of improvement it would be,
+> how much value it would have, and how recommended it would be. […] This is in
+> the idea of streamlining many things more obvious, things like that.
+
+The second asked for each idea to be verified against the codebase before
+acting:
+
+> Can you analyze each one of these and verify it to see what a recommended
+> change for each one is? And if any of those changes might break something
+> else or have […] side consequences that are unforeseen.
+
+Each item therefore carries: an **ID**, a **type** of improvement, a **value**
+rating, a **recommendation**, and — from the verification pass — a **verdict**
+plus the concrete **side-effects / coupling** discovered.
+
+## Context & approach
+
+The repo is a production-ready Python project *template*: a fork runs
+`just init` to rebrand identity literals across ~50 files, so the init system
+(`init/manifest.toml` + `init/ci/*` guards + `init-integration` CI) couples
+many files that look independent. Verification consisted of tracing each idea
+through that init machinery, the lefthook hooks, CI workflows, and
+cross-references before assigning a verdict.
+
+Execution model: **one single-purpose PR per item**, each verified end-to-end
+locally (`just check`, init suite, manifest drift, hooks un-bypassed) before a
+draft PR, then merged independently. This keeps every change separately
+reviewable and revertible.
+
+## Execution order
+
+| Order | ID | Item | Type | Value | Verdict |
+|-------|------|------|------|-------|---------|
+| done | SIMP-01 | Purge dead/legacy Justfile recipes | Dead-code removal | High | ✅ merged #401 |
+| done | SIMP-02 | Fix the broken docs toolchain | Drift fix / consolidation | High | ✅ merged #402 |
+| done | SIMP-03 | Two-level setup (`make bootstrap` + `just setup`) | Consolidation / DX | High | ✅ merged #405 |
+| 1 | SIMP-10 | Single-source CODE_OF_CONDUCT | DRY | Low-Med | Do — files byte-identical |
+| 2 | SIMP-11 | Move `skill/optimization-workspace/` out | Organization | Low-Med | Do — + manifest question |
+| 3 | SIMP-06 | Canonical AGENTS.md; thin vendor rules | DRY / consolidation | Med | Do — CI enforces the risk |
+| 4 | SIMP-08 | Group flat test files | Organization | Med | Do — mechanical |
+| 5 | SIMP-07 | Relocate root markdown | Organization | Med | Do — one scope question |
+| 6 | SIMP-09 | Consolidate single-purpose lint workflows | Consolidation | Med | Do last — one external check |
+| 7 (opt) | SIMP-04 | Reorganize the Justfile (in place) | Organization | Med | Defer/optional |
+| — | SIMP-05 | Replace the root Makefile | Simplification | — | **Dropped — superseded by SIMP-03** |
+| — | SIMP-12 | Merge the two commitlint configs | DRY | — | **Dropped — split is load-bearing** |
+
+The logic: items 1–3 touch disjoint files (any order; no rebases), 4–5 are the
+manifest-touching moves in increasing size, 6 waits on a repo-settings check
+only the maintainer can do quickly, and 7 is optional polish.
+
+## Completed work
+
+### SIMP-01 — Purge dead/legacy Justfile recipes (merged #401)
+
+Removed the legacy pip recipe set (`setup-venv`, `install-dev-pip`,
+`format-pip`, `lint-pip`, `typecheck-pip`, `test-pip`), the `_foo` demo recipe,
+and `install-go`. Rewrote `install-yamlfmt` to download the upstream pre-built
+binary (taplo-style) so Go is no longer an onboarding requirement just to
+format YAML. **Verification correction:** the original pass wrongly called
+`install-go` dead — `check-deps` hard-failed without Go because
+`install-yamlfmt` depended on it. Also fixed `check-deps` pointing at
+nonexistent `make install-go` / `make install-yamlfmt` targets. Docs updated
+(`cli_reference.md`, `justfiles.md`, `yaml_lint.md`).
+
+### SIMP-02 — Fix the broken docs toolchain (merged #402)
+
+`docs/Makefile`, `just init-docs`, and `just install-docs` were **broken on
+main** — they used `uv run --extra docs`, which fails since docs deps moved to
+a PEP 735 dependency group (ITM-063). Rewrote the docs recipes to call Sphinx
+directly via `uv run --group docs` (the path Read the Docs already uses),
+deleted `docs/Makefile` and `install-docs`. `install-docs` was independently
+broken (installed `sphinx-rtd-theme` while `conf.py` uses furo, off-lockfile).
+
+### SIMP-03 — Two-level setup (merged #405)
+
+Per maintainer refinement, made setup explicitly two-level:
+**Level 1** `make bootstrap` (base toolchain: just + uv), **Level 2**
+`just setup` (dev env sync, git hooks, hook toolchain). `just setup` gates on
+`make check` and fails with a pointer to `make bootstrap` if the base toolchain
+is missing. Devcontainer `postCreateCommand` now runs both levels via
+`.devcontainer/post-create.sh`. Fixed three live bugs: `SHELL := /bin/zsh` (the
+Makefile didn't run on stock Linux), `just install-dev` silently installing
+zero dev deps (stale `.[dev]` extra), and a stale `bun.lock` (commitlint
+19→21). CLAUDE.md + AGENTS.md document the flow as canonical.
+
+## Planned items
+
+### SIMP-10 — Single-source CODE_OF_CONDUCT (DRY · Low-Med value)
+
+`CODE_OF_CONDUCT.md` exists byte-identically in both `.github/` and
+`docs/source/contributing/` (`diff` clean). Keep `.github/` as the source
+(GitHub surfaces it natively) and have the Sphinx copy pull it in via a MyST
+`{include}`. Verified safe: RTD builds from a full checkout so `.github/` is
+present; neither file is in the init manifest. Only watch-out: Sphinx emits a
+"document outside source directory" warning — harmless unless docs builds turn
+on `-W` (they don't).
+
+### SIMP-11 — Move `skill/optimization-workspace/` out (Organization · Low-Med)
+
+`RESULTS.md` is an internal prompt-optimization writeup, not template content,
+and already forces a codespell skip in `pyproject.toml`. Move it to
+`docs/research/` (empty, exists for exactly this) and update `skill/README.md`
++ the codespell skip list. **Decision surfaced:** the manifest has no
+`[[remove]]` for `skill/` at all, so every fork ships the blueprint's own
+bootstrap skill. Whether to add a `skill/` removal is a judgment call (forks
+may want the skill) — to be raised in the PR, not decided incidentally.
+
+### SIMP-06 — Canonical AGENTS.md; thin vendor rules (DRY · Med)
+
+Five files carry overlapping guidance: `AGENTS.md`, `CLAUDE.md`,
+`.windsurfrules`, `.cursor/rules/projectenv.mdc`, `.windsurf/rules/`. Keep
+AGENTS.md canonical and detailed; reduce vendor files to pointers plus only
+genuinely vendor-specific content (CLAUDE.md keeps its project-harness
+section). Cursor and Windsurf both follow AGENTS.md now, so `.windsurfrules`
+and `.windsurf/` may be deletable. **Coupling:** `.windsurfrules` is in two
+manifest `[[replace]]` blocks (`app_name`, `package_name`); deleting it needs
+matching manifest edits — but `check_manifest_drift.py` runs on every PR and
+pre-push, so a miss fails loudly rather than shipping a broken fork.
+`.cursor/rules/projectenv.mdc` references `.windsurfrules` by name — update in
+the same change.
+
+### SIMP-08 — Group flat test files (Organization · Med)
+
+`tests/` is half-organized (`cli/`, `core/`, `web/` subdirs + 6 flat files).
+Group the repo/tooling meta-tests (`test_contributors_*`, `test_justfile`,
+`test_version_consistency`) under `tests/meta/`; move `test_output.py` to
+`tests/cli/`. **Coupling:** manifest has `[[remove]]` entries for the
+contributor/justfile tests and `[[replace]]` for output/version tests — paths
+must update on move (CI-enforced). `test_justfile.py` resolves root via
+`parents[1]` → becomes `parents[2]` one level deeper. New `tests/meta/`
+needs `__init__.py` (package-style suite). Codecov `paths: tests/` and pytest
+`testpaths` still match.
+
+### SIMP-07 — Relocate root markdown (Organization · Med)
+
+Move `POST_INIT.md` → `init/` (it documents the init system) and `RELEASE.md`
+→ `docs/`. **New fact (re-eval):** a prominent README link to `EXAMPLECLI.md`
+was added recently, suggesting its root placement may be deliberate — so the
+PR should ask whether to scope EXAMPLECLI.md out and keep it at root. Largest
+reference churn: manifest blocks, README, the `errors.py` docstring, and an
+absolute GitHub-blob link in `docs/source/index.md`. The strict-mode
+`init-integration` workflow + drift check make a missed manifest path fail CI,
+so misses can't silently merge.
+
+### SIMP-09 — Consolidate single-purpose lint workflows (Consolidation · Med)
+
+actionlint, codespell, editorconfig-check, yamllint, and bandit are each a
+checkout + one tool; they could be jobs in one `lint.yml` (separate jobs keep
+independent status checks). **External unknown — only the maintainer can
+confirm:** branch-protection / ruleset *required status checks* reference check
+names; keep job names identical and confirm in repo settings before deleting
+old workflow files, or a PR could wait forever on a check that never reports.
+Don't fold in `blueprint-guard.yml` / `update-contributors.yml` (manifest
+`[[remove]]` names them). `bandit.yml` is in the manifest `package_name` block
+— path update needed.
+
+## Dropped / deferred
+
+### SIMP-05 — Replace the root Makefile — **DROPPED (superseded by SIMP-03)**
+
+The original idea was to replace the Makefile with a bootstrap script. SIMP-03
+instead made the Makefile the *permanent* Level-1 bootstrap: `make bootstrap`
+is now load-bearing in the devcontainer, README quick start, CLAUDE.md, and
+AGENTS.md, and PR #403 added `install-flox` to it. Replacing it would undo
+just-merged architecture. The original SIMP-05 bug (zsh shebang, `~/bin` PATH
+handling) was folded into SIMP-03.
+
+### SIMP-12 — Merge the two commitlint configs — **DROPPED (split is load-bearing)**
+
+`commitlint.config.mjs` and `commitlint.dependabot.config.mjs` differ only in
+two line-length rules, but the split is structural: `commitlint.yml` selects
+the config per PR author (`user.login == 'dependabot[bot]'`) via the action's
+`configFile` input. Merging would mean plumbing an env var through a Docker
+action into the Node config — more fragile and less explicit than two
+well-commented files. The current design is correct.
+
+### SIMP-04 — Reorganize the Justfile — **DEFERRED (in-place only, optional)**
+
+Originally "split into imported modules"; **downgraded** during verification
+because a real `import` split breaks four init couplings: blueprint-guard
+Check 3 copies only `Justfile` + `init/` to a temp dir; `init/tests/conftest.py`
+builds fixtures from a curated list including `Justfile`; `init/init.py` prunes
+recipes from the root Justfile and `init_doctor.py` parses identity vars from
+it; and `check_guard_wiring.py` scans only the root file (a moved guarded
+recipe would *silently pass*). After SIMP-01 the file is ~780 lines and the
+pain is mostly gone. Do only as an in-place reorg if it still bothers the
+maintainer; the one worthwhile piece is extracting the ~200-line
+`pr-to-testrepo` bash body into `scripts/` with a thin wrapper (keeps its name,
+`: _guard` dep, and root location, so all four checks keep working).
+
+## References
+
+- Initiative originated from the simplification-ideas request (2026-06-12) and
+  a follow-up verification pass tracing each idea through `init/manifest.toml`,
+  `init/ci/{check_manifest_drift,check_guard_wiring,check_path_filter}.py`,
+  `lefthook.yml`, and `.github/workflows/`.
+- Merged PRs: #401 (SIMP-01), #402 (SIMP-02), #405 (SIMP-03).
+- Init-system contract that couples otherwise-independent files:
+  `init/manifest.toml` `[[replace]]`/`[[remove]]`/`[[rename]]` blocks, enforced
+  by `blueprint-guard` + `init-integration` CI (strict mode, every PR).


### PR DESCRIPTION
## P02 — Repo simplification & organization (SIMP series)

Captures the simplification/organization initiative as a tracked project following the `PROJECTS.md` convention: a trunk row in `PROJECTS.md` + a per-project file at `projects/P02-repo-simplification.md` (mirroring P01's structure).

### What's in the project file

- **Original requirement** — both framing requests quoted: the ranked simplification-ideas ask, and the follow-up to verify each idea for unforeseen side effects.
- **Context & approach** — why the init system couples seemingly-independent files, and the one-verified-single-purpose-PR-per-item model.
- **Execution order table** — the full SIMP-01..12 catalogue with each item's ID, type, value, and post-verification verdict.
- **Completed work** — SIMP-01/02/03 with their merged PRs (#401, #402, #405) and the bugs each fixed.
- **Planned items** — SIMP-10, 11, 06, 08, 07, 09, each with the concrete coupling/side-effects analysis from the verification pass.
- **Dropped / deferred** — SIMP-05 (superseded by SIMP-03), SIMP-12 (split is load-bearing), SIMP-04 (in-place reorg only, with the four init couplings that killed the module split).

### Notes

- The new file contains **no identity literals** (`plbp`, `py_launch_blueprint`, etc.), so no `init/manifest.toml` entry is required — drift check passes. (Worth a separate look someday: like P01, `projects/` files ship to forks via `just init`; that's existing convention, not changed here.)
- Project-harness skills (`project-add`) aren't available in this session, so the convention was followed by hand to match P01.

### Verification

- `check_manifest_drift.py` passes (no identity literals to cover)
- codespell + editorconfig-checker clean on both files
- commitlint + pre-push hooks passed un-bypassed on commit/push

https://claude.ai/code/session_01SMySE2CVBD3nFPLRZLC7vu

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMySE2CVBD3nFPLRZLC7vu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a registry entry for the repo-simplification initiative (P02) and its tracking status.
  * Added a comprehensive project plan detailing scope, execution model, prioritized items, outcomes, and verification notes.
  * Added ADR 0014 documenting accepted simplification decisions and consequences; updated ADR index.
  * Updated Code of Conduct page to mirror the single canonical source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->