### PR TITLE
test: yaml-only change to validate lint.yml path detection (positive case)

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -40,3 +40,6 @@ ignore: |
   .readthedocs.yaml
 
   .github/workflows/update-contributors.yml
+
+# lint-trigger validation (SIMP-09): yaml-only change — yamllint must run,
+# actionlint must be skipped. PR is closed after observing the checks.


### PR DESCRIPTION
**Validation PR — will be closed, not merged**, after observing the checks.

Positive case for the SIMP-09 path detection (#413): touches only `.yamllint`, so the `lint-changes` job must report `yaml=true workflows=false` → **`yamllint` runs, `actionlint` is skipped**, and bandit/codespell/editorconfig-check run as always.

Companion negative case: the markdown-only PR.

https://claude.ai/code/session_016AP6thiPp5BL2RNNT8o4qX

---
_Generated by [Claude Code](https://claude.ai/code/session_016AP6thiPp5BL2RNNT8o4qX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated validation configuration to enhance code quality checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->