### PR TITLE
test: markdown-only change to validate lint.yml path detection (negative case)

### DIFF
--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -17,3 +17,6 @@ itself mandate anything — when a conclusion is reached, capture it in a
 | Doc | Title | Date |
 |-----|-------|------|
 | [0001](0001-skill-trigger-optimization.md) | Trigger optimization for the `new-python-project` agent skill | 2026-06 |
+
+Lint-trigger validation note (SIMP-09): this markdown-only change must leave
+actionlint and yamllint skipped while bandit/codespell/editorconfig still run.


### PR DESCRIPTION
**Validation PR — will be closed, not merged**, after observing the checks.

Negative case for the SIMP-09 path detection (#413): touches only a docs markdown file, so the `lint-changes` job must report `yaml=false workflows=false` → **`actionlint` and `yamllint` are both skipped** (and a skipped job still satisfies any required check), while bandit/codespell/editorconfig-check run unconditionally.

Companion positive case: the yaml-only PR.

https://claude.ai/code/session_016AP6thiPp5BL2RNNT8o4qX

---
_Generated by [Claude Code](https://claude.ai/code/session_016AP6thiPp5BL2RNNT8o4qX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation with validation notes for development processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->