### PR TITLE
docs(projects): mark p02 repo-simplification complete

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -23,7 +23,7 @@ file by hand — see Conventions.
 | ID  | St    | Project                                                                 |
 |-----|-------|------------------------------------------------------------------------|
 | P01 | `[x]` | [Init app-name rebrand robustness](projects/P01-init-rebrand-robustness.md) — per-field drift coverage (B) + derive non-contract internals (C) |
-| P02 | `[~]` | [Repo simplification & organization (SIMP series)](projects/P02-repo-simplification.md) — single-purpose PRs to simplify/consolidate Justfile, docs, setup, tests, workflows, agent configs |
+| P02 | `[x]` | [Repo simplification & organization (SIMP series)](projects/P02-repo-simplification.md) — single-purpose PRs to simplify/consolidate Justfile, docs, setup, tests, workflows, agent configs |
 
 ## Conventions
 

--- a/projects/P02-repo-simplification.md
+++ b/projects/P02-repo-simplification.md
@@ -1,6 +1,6 @@
 # P02 — Repo simplification & organization (SIMP series)
 
-- **Status:** `[~]` in progress — SIMP-01/02/03 merged; SIMP-10 in #407; SIMP-11/06/08/07/09 implemented in PRs #409–#413 (awaiting review/merge); SIMP-04/05/12 dropped or deferred
+- **Status:** `[x]` complete (2026-06-12) — SIMP-01/02/03 merged (#401/#402/#405); SIMP-10 in #407; SIMP-11/06/08/07/09 merged (#409–#413); SIMP-05/12 dropped; SIMP-04 deferred as optional (in-place Justfile reorg only, if ever). Decisions recorded in ADR 0014; lint path-detection validated live in #415/#416.
 - **Captured:** 2026-06-12
 - **Scope:** repo-wide structure & tooling — `Justfile`, `Makefile`, `docs/`,
   `tests/`, `.github/workflows/`, agent-config files, root markdown


### PR DESCRIPTION
Marks P02 `[x]` complete in the trunk and the project file: all SIMP items merged (#401/#402/#405, #407, #409–#413) or deliberately dropped, with SIMP-04 recorded as deferred-optional. Decisions live in ADR 0014; the lint path-detection was validated live in #415/#416.

https://claude.ai/code/session_016AP6thiPp5BL2RNNT8o4qX

---
_Generated by [Claude Code](https://claude.ai/code/session_016AP6thiPp5BL2RNNT8o4qX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project completion status in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->