### PR TITLE
docs(post-init): document the ci-ok-anchored branch-protection baseline

### DIFF
--- a/docs/POST_INIT.md
+++ b/docs/POST_INIT.md
@@ -150,11 +150,11 @@ init/setup-github-environments.sh <owner>/<repo>
 Under **Settings**:
 
 - [ ] **Branch protection** on `main`: require status checks anchored on the
-      aggregate gates — `ci-ok` (all of ci.yml), `integration-ok`, `guard`,
+      aggregate gates — `ci-ok` (all of `ci.yml`), `integration-ok`, `guard`,
       `unit-tests`, `commitlint (humans)`, plus the `lint.yml` job names
       (`actionlint`, `bandit`, `codespell`, `editorconfig-check`, `yamllint`;
       safe to require — they report *skipped* rather than never reporting).
-      Avoid listing individual ci.yml jobs: `ci-ok` subsumes them and its
+      Avoid listing individual `ci.yml` jobs: `ci-ok` subsumes them and its
       `needs:` list is versioned in-repo, so job renames never desync the
       settings. Full command in [§3.6](#36-branch-protection).
 - [ ] **Actions → General → Workflow permissions**: enable **"Allow GitHub
@@ -264,7 +264,7 @@ you need (`gh secret set NAME -R <owner>/<repo>` prompts for the value).
   - Set (recommended baseline — aggregate gates + always-reporting linters):
 
     ```bash
-    gh api -X PUT repos/<owner>/<repo>/branches/main/protection --input - <<'JSON'
+    gh api -X PUT /repos/<owner>/<repo>/branches/main/protection --input - <<'JSON'
     {
       "required_status_checks": {
         "strict": false,

--- a/docs/POST_INIT.md
+++ b/docs/POST_INIT.md
@@ -149,9 +149,14 @@ init/setup-github-environments.sh <owner>/<repo>
 
 Under **Settings**:
 
-- [ ] **Branch protection** on `main`: require PR reviews, require status checks
-      (e.g. `ci`, `commitlint`, `codeql`), and (optionally) linear history. The
-      template assumes a protected `main` with required reviews.
+- [ ] **Branch protection** on `main`: require status checks anchored on the
+      aggregate gates — `ci-ok` (all of ci.yml), `integration-ok`, `guard`,
+      `unit-tests`, `commitlint (humans)`, plus the `lint.yml` job names
+      (`actionlint`, `bandit`, `codespell`, `editorconfig-check`, `yamllint`;
+      safe to require — they report *skipped* rather than never reporting).
+      Avoid listing individual ci.yml jobs: `ci-ok` subsumes them and its
+      `needs:` list is versioned in-repo, so job renames never desync the
+      settings. Full command in [§3.6](#36-branch-protection).
 - [ ] **Actions → General → Workflow permissions**: enable **"Allow GitHub
       Actions to create and approve pull requests"** (release-please and
       Dependabot open PRs).
@@ -253,9 +258,35 @@ you need (`gh secret set NAME -R <owner>/<repo>` prompts for the value).
 
 ### 3.6 Branch protection
 
-- [ ] **Protect `main`** · *repo setting* — require PR review + status checks.
+- [ ] **Protect `main`** · *repo setting* — require status checks (contexts are
+  **job names** as shown on a PR's checks tab, not workflow filenames).
   - Check: `gh api /repos/<owner>/<repo>/branches/main/protection --jq '.required_pull_request_reviews, .required_status_checks.contexts' 2>/dev/null || echo "unprotected"`
-  - Set: add a rule in Settings → Branches (or `gh api --method PUT …/branches/main/protection` with a JSON body). Required-check contexts should match the names on a PR's checks (e.g. `ci`, `commitlint`, `analyze (python)`, `trufflehog`, `yamllint`).
+  - Set (recommended baseline — aggregate gates + always-reporting linters):
+
+    ```bash
+    gh api -X PUT repos/<owner>/<repo>/branches/main/protection --input - <<'JSON'
+    {
+      "required_status_checks": {
+        "strict": false,
+        "contexts": [
+          "ci-ok", "integration-ok", "guard", "unit-tests",
+          "commitlint (humans)",
+          "actionlint", "bandit", "codespell", "editorconfig-check", "yamllint"
+        ]
+      },
+      "enforce_admins": false,
+      "required_pull_request_reviews": null,
+      "restrictions": null,
+      "allow_force_pushes": false,
+      "allow_deletions": false
+    }
+    JSON
+    ```
+
+  - Knobs: `strict: true` additionally forces every PR up-to-date with `main`
+    before merge (safer, but every merge invalidates all other open PRs);
+    `enforce_admins: true` removes the admin escape hatch; add
+    `required_pull_request_reviews` once you have collaborators.
 
 ### 3.7 External services (UI / no `gh` check)
 


### PR DESCRIPTION
Adds the branch-protection setup as a concrete post-init step, replacing the stale example contexts (`ci`, `commitlint`, `codeql`):

- §2.4 checklist row now describes the **`ci-ok`-anchored baseline** and why individual ci.yml jobs shouldn't be listed (the `needs:` list is versioned in-repo, so job renames never desync settings).
- §3.6 carries the full copy-pasteable `gh api PUT` command with the recommended contexts — the aggregate gates (`ci-ok`, `integration-ok`, `guard`, `unit-tests`, `commitlint (humans)`) plus the `lint.yml` job names, which are safe to require post-SIMP-09 because they report *skipped* rather than never reporting — and notes on the `strict` / `enforce_admins` knobs.

Uses the doc's existing `<owner>/<repo>` placeholder convention, so no manifest changes (drift check passes).

https://claude.ai/code/session_016AP6thiPp5BL2RNNT8o4qX

---
_Generated by [Claude Code](https://claude.ai/code/session_016AP6thiPp5BL2RNNT8o4qX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated branch protection guidance to instruct using aggregate required status checks instead of listing individual workflow checks.
  * Added a concrete example command for configuring required status check contexts.
  * Clarified the behavior of the "strict" and "enforce_admins" settings and removed prior looser examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->