### PR TITLE
fix: add PyPI fallback for just installation and fix CI skip paths

### DIFF
--- a/.github/workflows/blueprint-guard.yml
+++ b/.github/workflows/blueprint-guard.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:  # required checks must also report on the merge queue's speculative merge
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # The merge queue emits merge_group (not pull_request) for its speculative
+  # merge — without this trigger the ci-ok required check never reports and
+  # every queue entry deadlocks at "Expected".
+  merge_group:
 
 permissions: {}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,10 @@ jobs:
           # a packaging input that build-smoke must validate (CodeRabbit).
           skip='^docs/|^assets/|^\.vscode/|^\.cursor/|^\.windsurf|\.md$'
           skip="$skip|^LICENSE$|^\.github/ISSUE_TEMPLATE/"
+          # .contributors.jsonl is contributors-please's generated ledger -
+          # bookkeeping only, so the weekly bot PR stays on the docs-only
+          # fast path now that its commits no longer carry [skip ci].
+          skip="$skip|^\.contributors\.jsonl$"
           changed="$(git diff --name-only "${BASE_SHA}...HEAD")"
           if printf '%s\n' "$changed" | grep -qx 'README\.md' \
               || printf '%s\n' "$changed" \

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -18,6 +18,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:  # job must report inside the merge queue; lint step no-ops there
 
 permissions: {}
 
@@ -37,7 +38,10 @@ jobs:
         with:
           fetch-depth: 0  # range scan needs full history
 
+      # On merge_group there are no PR commits to lint (they were already
+      # linted on the PR) — skip the step so the required check reports green.
       - name: commitlint
+        if: github.event_name != 'merge_group'
         uses: wagoid/commitlint-github-action@v6.2.1
         with:
           configFile: commitlint.config.mjs

--- a/.github/workflows/init-integration.yml
+++ b/.github/workflows/init-integration.yml
@@ -33,6 +33,7 @@ name: init-integration
 
 on:
   pull_request:
+  merge_group:  # required checks must also report on the merge queue's speculative merge
   push:
     branches: [main]
   schedule:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:  # required checks must also report on the merge queue's speculative merge
 
 permissions: {}
 

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -33,3 +33,9 @@ jobs:
           state-file: .contributors.jsonl
           config-file: .contributors.yml
           mode: pull-request
+          # Override the action's default ("docs: update contributors
+          # [skip ci]"): [skip ci] suppresses the pull_request workflows
+          # behind main's required checks, leaving the bot PR permanently
+          # blocked. Loop protection comes from paths-ignore above, not
+          # from [skip ci].
+          commit-message: "docs: update contributors"

--- a/Makefile
+++ b/Makefile
@@ -45,19 +45,27 @@ all: help
 # Level 2: `just setup` (dev env sync, git hooks, hook toolchain).
 # Do not add project tasks here; they belong in the Justfile.
 
-bootstrap: ## Level 1 — install base toolchain (just + uv) if missing, then verify
-	@if command -v just >/dev/null 2>&1; then \
-		echo -e "[$(CHECK)] just already installed"; \
-	else \
-		echo "Installing just to $(HOME)/.local/bin..."; \
-		mkdir -p "$(HOME)/.local/bin"; \
-		curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$(HOME)/.local/bin"; \
-	fi
+# uv installs first so the just fallback below can rely on it. Primary just
+# install (just.systems) resolves the latest release via the anonymous GitHub
+# API, which 403s on rate-limited shared IPs (CI, cloud agents); the fallback
+# pulls the latest rust-just from PyPI, which has no such limit.
+bootstrap: ## Level 1 — install base toolchain (uv + just) if missing, then verify
 	@if command -v uv >/dev/null 2>&1; then \
 		echo -e "[$(CHECK)] uv already installed"; \
 	else \
 		echo "Installing uv..."; \
 		curl -LsSf https://astral.sh/uv/install.sh | sh; \
+	fi
+	@if command -v just >/dev/null 2>&1; then \
+		echo -e "[$(CHECK)] just already installed"; \
+	else \
+		echo "Installing just to $(HOME)/.local/bin..."; \
+		mkdir -p "$(HOME)/.local/bin"; \
+		curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$(HOME)/.local/bin" \
+		|| { \
+			echo "just.systems installer failed — falling back to PyPI (rust-just) via uv..."; \
+			PATH="$(HOME)/.local/bin:$$PATH" uv tool install rust-just; \
+		}; \
 	fi
 	@PATH="$(HOME)/.local/bin:$$PATH" $(MAKE) --no-print-directory check
 	@echo ""
@@ -152,13 +160,18 @@ install-just: ## Print install just command and where to find install options
 	@echo "or"
 	@echo -e "${CYAN}make install-just-force${NC}"
 	@echo "NOTE:change ~/.local/bin to the desired installation directory"
+	@echo -e "PyPI fallback (no GitHub API rate limit): ${CYAN}uv tool install rust-just${NC}"
 	@echo "Find other install options here: https://github.com/casey/just"
 	@echo -e "To setup just PATH, run: ${YELLOW}SET_PATH=$(HOME)/.local/bin make set-path${NC}"
 
-install-just-force: ## Install just to ~/.local/bin
+install-just-force: ## Install just to ~/.local/bin (PyPI fallback if uv present)
 	@echo "Installing just to $(HOME)/.local/bin..."
 	@mkdir -p "$(HOME)/.local/bin"
-	@curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$(HOME)/.local/bin"
+	@curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$(HOME)/.local/bin" \
+	|| { \
+		echo "just.systems installer failed — falling back to PyPI (rust-just) via uv..."; \
+		PATH="$(HOME)/.local/bin:$$PATH" uv tool install rust-just; \
+	}
 	@echo -e "If $(HOME)/.local/bin is not on your PATH, add it (bash: ~/.bashrc, zsh:"
 	@echo -e "$(YELLOW)SET_PATH=$(HOME)/.local/bin make set-path$(NC)), then open a new terminal."
 

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,13 @@ install-just-force: ## Install just to ~/.local/bin (PyPI fallback if uv present
 	@curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$(HOME)/.local/bin" \
 	|| { \
 		echo "just.systems installer failed — falling back to PyPI (rust-just) via uv..."; \
-		PATH="$(HOME)/.local/bin:$$PATH" uv tool install rust-just; \
+		if PATH="$(HOME)/.local/bin:$$PATH" command -v uv >/dev/null 2>&1; then \
+			PATH="$(HOME)/.local/bin:$$PATH" uv tool install rust-just; \
+		else \
+			echo -e "$(CROSS) uv not found — install it first ($(YELLOW)make install-uv-force$(NC)) and retry,"; \
+			echo "  or see other just install options: https://github.com/casey/just"; \
+			exit 1; \
+		fi; \
 	}
 	@echo -e "If $(HOME)/.local/bin is not on your PATH, add it (bash: ~/.bashrc, zsh:"
 	@echo -e "$(YELLOW)SET_PATH=$(HOME)/.local/bin make set-path$(NC)), then open a new terminal."


### PR DESCRIPTION
## Feature Description

This PR improves the robustness of the `just` command-line tool installation process by adding a PyPI fallback mechanism when the primary installer fails due to GitHub API rate limiting. It also fixes CI workflow configuration to properly handle generated files and prevent workflow blocking.

## Implementation Details

**Installation Resilience:**
- Reordered bootstrap to install `uv` first, enabling it as a fallback for `just` installation
- Added error handling with fallback to `rust-just` via PyPI when the primary `just.systems` installer fails
- This addresses rate-limiting issues on shared IPs (CI environments, cloud agents) that can block the GitHub API-based installer
- Applied the same fallback pattern to the `install-just-force` target for consistency

**CI/CD Improvements:**
- Updated `update-contributors` workflow to remove `[skip ci]` from commit messages, which was blocking required checks on the bot's PR
- Added `.contributors.jsonl` to the CI skip paths since it's a generated ledger file (bookkeeping only)
- Added explanatory comments documenting why these changes prevent workflow blocking

## Changes Made

- Modified `Makefile` bootstrap target to install `uv` before `just` and add PyPI fallback
- Updated `install-just-force` target with same fallback mechanism
- Updated `install-just` help text to document the PyPI fallback option
- Modified `.github/workflows/update-contributors.yml` to remove `[skip ci]` from commit message
- Updated `.github/workflows/ci.yml` to skip `.contributors.jsonl` in change detection

## Testing Performed

- Changes are configuration/tooling updates with no new code logic requiring unit tests
- CI workflow changes will be validated by the next bot PR run
- Installation fallback will be tested when GitHub API rate limiting occurs in CI environments

## Documentation Updates

- Added inline comments in Makefile explaining the installation fallback strategy
- Added comments in GitHub Actions workflows explaining the skip path and commit message changes
- Updated help text in `install-just` target to mention PyPI fallback option

## Breaking Changes

None

## Checklist

- [x] Branch name follows convention
- [x] Commit messages follow Conventional Commits
- [x] No CHANGELOG.md entry needed (tooling/CI changes)
- [x] Changes are configuration updates with no code logic requiring tests
- [x] Self-review of code performed
- [x] No debug statements or commented-out code

## Reviewer Notes

The key insight is that the GitHub API-based `just` installer fails on rate-limited shared IPs (common in CI and cloud environments), while the PyPI-based `rust-just` package has no such limitation. The fallback ensures bootstrap reliability across all environments. The CI workflow changes prevent the contributors bot PR from being permanently blocked by required checks.

https://claude.ai/code/session_01NmD1TGnHZNXks3nTbcxHhd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Workflow triggers updated to run required checks for merge-queue speculative merges.
  * Commitlint adjusted to skip redundant linting during merge-queue runs.
  * CI now treats contributor bookkeeping file as generated so docs-only PRs skip heavy checks while preserving the aggregate gate.
  * Contributor-update automation uses an explicit commit message so bot PRs run required checks.
  * Bootstrap installer flow improved with clearer fallbacks for missing tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->