### PR TITLE
ci: keep openapi snapshot version in sync via release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,6 +11,11 @@
           "type": "toml",
           "path": "pyproject.toml",
           "jsonpath": "$.project.version"
+        },
+        {
+          "type": "json",
+          "path": "docs/api/openapi.json",
+          "jsonpath": "$.info.version"
         }
       ],
       "changelog-sections": [


### PR DESCRIPTION
## Problem

The version number lives in **two** committed places:

1. `pyproject.toml` → `$.project.version` (canonical)
2. `docs/api/openapi.json` → `$.info.version` (snapshot of the FastAPI spec)

The app builds the spec's version from the package version at runtime, and
`test_openapi_snapshot_is_current` asserts the regenerated spec byte-matches the
committed snapshot — so the two must always agree.

release-please's `extra-files` listed **only** `pyproject.toml`, so on every
release PR it bumped the canonical version but left `openapi.json` at the old
version:

```
release-please bumps version for the release PR
├─► pyproject.toml      $.project.version : 2.1.0 → 2.1.1   ✅ (in extra-files)
└─► docs/api/openapi.json  $.info.version : 2.1.0 → 2.1.1   ❌ NOT touched
                                               ▼
CI: app builds spec at runtime → "2.1.1";  committed snapshot → "2.1.0"
└─► test_openapi_snapshot_is_current: "2.1.1" != "2.1.0" → AssertionError
        → all 6 test jobs fail → ci-ok fails → release PR blocked
```

This first surfaced on #422 (release v2.1.1), where it was fixed by hand
(`just export-openapi` + commit). Without this change, every future release PR
reproduces the identical failure.

## Fix

Add `openapi.json` to the same `extra-files` list so the bot bumps both copies
in the same commit:

```jsonc
"extra-files": [
  { "type": "toml", "path": "pyproject.toml",        "jsonpath": "$.project.version" },
  { "type": "json", "path": "docs/api/openapi.json", "jsonpath": "$.info.version" }   // added
]
```

Now both move together and the snapshot test never sees a mismatch:

```
├─► pyproject.toml      $.project.version : X → X+1   ✅
└─► docs/api/openapi.json  $.info.version : X → X+1   ✅ (new)
                                               ▼
CI: runtime "X+1" == committed "X+1" → test passes
```

## Scope / caveat

`extra-files` does a **surgical edit of only the `$.info.version` string** — it
does not regenerate the whole spec. That's exactly right for a version bump (the
only thing changing between releases is that string). It deliberately does **not**
cover the case where someone edits an API route and forgets to run
`just export-openapi` — that's a separate failure mode, still caught on the
feature PR by the snapshot test and the api-contract workflow.

The snapshot is already at 2.1.1, so this is purely forward-looking; no snapshot
regen is included here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmD1TGnHZNXks3nTbcxHhd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration to ensure API documentation version remains synchronized with release versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->