### PR TITLE
ci: make openapi snapshot version-independent, drop release-please json updater

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "py-launch-blueprint",
     "description": "REST API over the same core library the CLI uses. Errors are RFC 9457 `application/problem+json`; business routes live under `/v1`; collections paginate with `page`/`size` query params.",
-    "version": "2.2.0"
+    "version": "0.0.0"
   },
   "paths": {
     "/healthz": {
@@ -70,7 +70,7 @@
           "projects"
         ],
         "summary": "List Projects",
-        "description": "List projects, optionally filtered by workspace name.\n\nPagination window note: pages are sliced from one upstream fetch (the\nservice's default limit), so ``total`` reflects the fetched window, not\nthe upstream universe. True pass-through pagination needs cursor support\nin ``ProjectsService`` — deferred; see \"Deliberately deferred\" in\ndocs/design/0002-web-api-conventions.md.",
+        "description": "List projects, optionally filtered by workspace name.\n\nPagination window note: pages are sliced from one upstream fetch (the\nservice's default limit), so ``total`` reflects the fetched window, not\nthe upstream universe. True pass-through pagination needs cursor support\nin ``ProjectsService`` \u2014 deferred; see \"Deliberately deferred\" in\ndocs/design/0002-web-api-conventions.md.",
         "operationId": "projects-list_projects",
         "parameters": [
           {
@@ -239,22 +239,22 @@
           },
           "total": {
             "type": "integer",
-            "minimum": 0,
+            "minimum": 0.0,
             "title": "Total"
           },
           "page": {
             "type": "integer",
-            "minimum": 1,
+            "minimum": 1.0,
             "title": "Page"
           },
           "size": {
             "type": "integer",
-            "minimum": 1,
+            "minimum": 1.0,
             "title": "Size"
           },
           "pages": {
             "type": "integer",
-            "minimum": 0,
+            "minimum": 0.0,
             "title": "Pages"
           }
         },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,11 +11,6 @@
           "type": "toml",
           "path": "pyproject.toml",
           "jsonpath": "$.project.version"
-        },
-        {
-          "type": "json",
-          "path": "docs/api/openapi.json",
-          "jsonpath": "$.info.version"
         }
       ],
       "changelog-sections": [

--- a/scripts/export_openapi.py
+++ b/scripts/export_openapi.py
@@ -18,6 +18,10 @@ from py_launch_blueprint.web.settings import WebSettings
 
 DEFAULT_OUT = "docs/api/openapi.json"
 
+# The committed snapshot is a version-independent contract (see export() below).
+# Keep this in sync with tests/web/test_openapi_snapshot.py.
+SNAPSHOT_VERSION = "0.0.0"
+
 
 def export(out: str = DEFAULT_OUT) -> Path:
     """Generate and write the canonical OpenAPI snapshot.
@@ -31,6 +35,14 @@ def export(out: str = DEFAULT_OUT) -> Path:
     # model_construct: pure field defaults, no env — the snapshot must not
     # depend on the exporting machine's environment.
     spec = create_app(WebSettings.model_construct()).openapi()
+    # Pin info.version to a fixed sentinel so the committed snapshot is a pure
+    # route/schema contract, independent of the package version. Otherwise the
+    # snapshot goes stale on every release (the runtime spec derives its version
+    # from package metadata) and either fails the snapshot test or has to be
+    # re-bumped by release-please — which round-trips and reformats the whole
+    # file. The real version stays single-sourced in pyproject.toml and is
+    # guarded by tests/meta/test_version_consistency.py.
+    spec["info"]["version"] = SNAPSHOT_VERSION
     path = Path(out)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(spec, indent=2) + "\n", encoding="utf-8")

--- a/tests/web/test_openapi_snapshot.py
+++ b/tests/web/test_openapi_snapshot.py
@@ -10,12 +10,18 @@ from pathlib import Path
 
 from py_launch_blueprint.web.app import create_app
 from py_launch_blueprint.web.settings import WebSettings
+from scripts.export_openapi import SNAPSHOT_VERSION
 
 SNAPSHOT = Path(__file__).resolve().parents[2] / "docs" / "api" / "openapi.json"
 
 
 def test_openapi_snapshot_is_current():
     generated = create_app(WebSettings.model_construct()).openapi()
+    # The committed snapshot pins info.version to a sentinel so it stays a pure
+    # route/schema contract (see scripts/export_openapi.py); normalize the
+    # runtime spec the same way before comparing. Version drift is guarded
+    # separately by tests/meta/test_version_consistency.py.
+    generated["info"]["version"] = SNAPSHOT_VERSION
     committed = json.loads(SNAPSHOT.read_text(encoding="utf-8"))
     assert generated == committed, (
         "docs/api/openapi.json is stale — run `just export-openapi` and commit"


### PR DESCRIPTION
## Background

#427 added `docs/api/openapi.json` to release-please's `extra-files` so the
snapshot's `$.info.version` got bumped on every release (the runtime spec derives
its version from package metadata, so the committed snapshot went stale otherwise
and failed `test_openapi_snapshot_is_current` — see #422).

That worked, but I flagged a concern in #427's description that turned out to be
**partly wrong**, and digging in revealed the cleaner fix.

## What I got wrong, and the real situation

I claimed release-please's re-serialization could "trip the snapshot test on a
future release." It can't. The test compares **parsed dicts**, not bytes:

```python
generated = create_app(...).openapi()          # dict
committed = json.loads(SNAPSHOT.read_text())    # dict
assert generated == committed
```

`0.0 == 0` and `json.loads('"\\u2014"') == json.loads('"—"')` are both `True`, so
release-please's number/unicode normalization is invisible to the test (verified
empirically). The **only** real residual was **byte churn**: release-please's JS
serializer writes `0`/`—`, while `just export-openapi` (Python `json.dumps`,
`ensure_ascii=True`) writes `0.0`/`—`. After a release the committed file is
in release-please's format; the next manual `export-openapi` flips the whole file
back, producing noisy diffs in unrelated PRs.

## Fix

Make the snapshot a **pure route/schema contract, independent of version**:

- `scripts/export_openapi.py` pins `info.version` to a fixed sentinel
  (`SNAPSHOT_VERSION = "0.0.0"`) before writing.
- `tests/web/test_openapi_snapshot.py` normalizes the runtime spec's version to
  the same sentinel before comparing.
- `release-please-config.json` drops the `openapi.json` entry — release-please no
  longer touches the file, so **one writer** (`export-openapi`) owns it. No
  re-serialization, no churn, and the original stale-on-release failure mode is
  gone at the source.

The real version stays single-sourced in `pyproject.toml` (still in `extra-files`)
and is guarded by `tests/meta/test_version_consistency.py` (pyproject ↔ manifest ↔
installed `__version__`) — which never referenced the OpenAPI snapshot, so no
version-drift coverage is lost.

## Verification

- `pytest tests/web tests/meta -m ""` → 59 passed.
- `just export-openapi` is now deterministic regardless of the installed package
  version (snapshot always `0.0.0`).
- The one-time `openapi.json` diff here reverts the file from release-please's
  format (from the 2.2.0 release) back to canonical `export-openapi` format; from
  here it only changes when routes/schemas change.

## Note

The `openapi.json` diff includes formatting normalizations (`0`→`0.0`,
`—`→`—`) — these are byte-only; the spec is semantically identical, and
oasdiff/api-contract treats the version change as non-breaking (confirmed on #429,
where the version moved 2.1.1→2.2.0).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmD1TGnHZNXks3nTbcxHhd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Locked API specification version to a stable snapshot value (0.0.0) to maintain consistent documentation across releases.
- Updated numeric validation constraints for pagination in the projects endpoint schema.
- Decoupled API documentation snapshot generation from package version management.
- Modified API snapshot tests to normalize version comparisons during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->