### PR TITLE
test: assert runtime openapi version matches __version__ before normalizing

### DIFF
--- a/tests/web/test_openapi_snapshot.py
+++ b/tests/web/test_openapi_snapshot.py
@@ -8,6 +8,7 @@ oasdiff against the base branch to call out breaking changes.
 import json
 from pathlib import Path
 
+from py_launch_blueprint import __version__
 from py_launch_blueprint.web.app import create_app
 from py_launch_blueprint.web.settings import WebSettings
 from scripts.export_openapi import SNAPSHOT_VERSION
@@ -17,6 +18,11 @@ SNAPSHOT = Path(__file__).resolve().parents[2] / "docs" / "api" / "openapi.json"
 
 def test_openapi_snapshot_is_current():
     generated = create_app(WebSettings.model_construct()).openapi()
+    # The runtime spec must carry the real package version (create_app wires
+    # info.version = __version__). Assert that here so pinning the snapshot to a
+    # version-independent sentinel below doesn't drop the coverage that the old
+    # full-dict compare gave for free.
+    assert generated["info"]["version"] == __version__
     # The committed snapshot pins info.version to a sentinel so it stays a pure
     # route/schema contract (see scripts/export_openapi.py); normalize the
     # runtime spec the same way before comparing. Version drift is guarded


### PR DESCRIPTION
Follow-up to #431, addressing a valid Copilot review point ([#431 review](https://github.com/smorinlabs/py-launch-blueprint/pull/431#discussion_r3408886642)).

#431 made the snapshot test normalize `info.version` to a sentinel before
comparing. That dropped the implicit coverage the old full-dict compare gave for
free: it no longer verified that the runtime spec actually carries the real
package version (a bug where `create_app()` set a wrong `version` would slip
through).

`create_app` wires `version=__version__` (`web/app.py`), and `__version__` is
`importlib.metadata.version(...)`. This restores the check with an explicit
assertion **before** the sentinel normalization:

```python
assert generated["info"]["version"] == __version__
generated["info"]["version"] = SNAPSHOT_VERSION
```

This complements `tests/meta/test_version_consistency.py` (which checks
`__version__` ↔ pyproject ↔ manifest) by covering the web layer's wiring of that
version into the OpenAPI spec — which nothing else asserts.

Verified: `pytest tests/web/test_openapi_snapshot.py tests/meta -m ""` → 9 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmD1TGnHZNXks3nTbcxHhd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced OpenAPI documentation validation to verify version consistency between generated and committed API specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->