### PR TITLE
docs(adr): add 0017 — hexagonal core with mechanical boundary enforcement

### DIFF
--- a/docs/adr/0017-hexagonal-core-and-boundary-enforcement.md
+++ b/docs/adr/0017-hexagonal-core-and-boundary-enforcement.md
@@ -3,10 +3,10 @@
 - **Status:** Accepted
 - **Date:** 2026-06-14
 - **Deciders:** Steve Morin (maintainer)
-- **Related:** design [`0005-hexagonal-architecture-and-enforcement.md`](../design/0005-hexagonal-architecture-and-enforcement.md)
-  (the spec + `HEX-xx` rules); PR #433 (implementation); ADR
-  [0015](0015-one-logging-pipeline-two-profiles.md) (the same CLI-vs-web
-  front-end split)
+- **Related:** design
+  [`0005`](../design/0005-hexagonal-architecture-and-enforcement.md)
+  (spec + `HEX-xx` rules); PR #433 (implementation);
+  ADR [0015](0015-one-logging-pipeline-two-profiles.md) (CLI-vs-web split)
 
 ## Context
 

--- a/docs/adr/0017-hexagonal-core-and-boundary-enforcement.md
+++ b/docs/adr/0017-hexagonal-core-and-boundary-enforcement.md
@@ -1,0 +1,81 @@
+# 0017. Hexagonal core with mechanical boundary enforcement
+
+- **Status:** Accepted
+- **Date:** 2026-06-14
+- **Deciders:** Steve Morin (maintainer)
+- **Related:** design [`0005-hexagonal-architecture-and-enforcement.md`](../design/0005-hexagonal-architecture-and-enforcement.md)
+  (the spec + `HEX-xx` rules); PR #433 (implementation); ADR
+  [0015](0015-one-logging-pipeline-two-profiles.md) (the same CLI-vs-web
+  front-end split)
+
+## Context
+
+The package serves one core from multiple front-ends — the Click CLI today,
+the FastAPI service behind the `web` extra, and more later. Before this
+decision the business logic already lived in `core/` (good), but
+`ProjectsService` was simultaneously the use-case **and** the HTTP client, and
+nothing prevented the CLI and web layers — or a future contributor — from
+importing across boundaries or binding directly to infrastructure. The instinct
+was right; the boundaries were neither explicit nor enforced.
+
+Three common patterns exist for a core driven by several interfaces: a shared
+in-process library, a CLI that is a thin client of the web API, and the
+formalized ports-and-adapters variant of the first. The trade-offs are surveyed
+in design 0005.
+
+## Decision
+
+We will structure the core as **ports & adapters (hexagonal)** — a shared
+in-process library with dependency inversion at every I/O seam — and **enforce
+the boundaries mechanically** rather than by convention:
+
+- Business logic depends on abstract **ports** (`typing.Protocol`); concrete
+  **adapters** (HTTP, in-memory) implement them; a **composition root** wires
+  them; the CLI and web layers are driving adapters that translate to/from
+  their transport.
+- Dependencies point inward only; the CLI and web layers never import each
+  other; framework imports (`fastapi`/`click`/`uvicorn`) stay out of `core/`.
+- Enforcement: **`import-linter`** is the authoritative graph-wide check
+  (layering, front-end independence, composition-root isolation,
+  framework-bleed) at `just check` + pre-push; **`tach`** guards
+  bounded-context isolation; **`ruff` TID251** is a fast pre-commit
+  framework-bleed guard scoped to `core/`; **`ty`** verifies adapters satisfy
+  the ports.
+- We do **not** adopt the CLI-over-HTTP pattern: the CLI talks to the core
+  in-process, because nothing here is a remote, multi-tenant deployment.
+
+Each rule carries a `HEX-xx` id; the full specification and the staged
+migration plan live in design 0005.
+
+## Consequences
+
+- **Easier:** swapping a real adapter for an in-memory fake makes business
+  logic testable without mocking `requests` (the test pyramid, HEX-40); adding
+  a third front-end is a thin adapter; boundary violations fail CI instead of
+  rotting silently.
+- **Harder / cost:** more indirection (ports, a composition root, more files)
+  than a two-endpoint tool strictly needs, and two extra dev-group tools
+  (`import-linter`, `tach`) to keep current. Accepted deliberately to set the
+  growth pattern.
+- **Follow-on work (deferred, tracked in 0005):** moving the CLI view models
+  out of `core/` (HEX-15) is blocked on decoupling the result-model-as-output
+  contract that `core/diagnostics` produces and the web returns; the
+  feature-first directory reshape (HEX-02 / migration step 5) waits for a
+  second bounded context.
+- The new dev tools follow the existing `uv run` dev-group pattern (per ADR
+  0005's lean toolchain) — they are **not** added to `mise`/`flox`.
+
+## Alternatives considered
+
+- **Shared in-process library without formal ports** — the status quo.
+  Rejected: the use-case/transport fusion blocked fakes-not-mocks testing and
+  nothing prevented boundary erosion.
+- **CLI as a thin client of the web API (CLI-over-HTTP)** — rejected: it adds a
+  network boundary, serialization, and a running-server dependency that only
+  pay off when the CLI manages a remote service, which is not the case here.
+- **Enforce by convention / code review only** — rejected: conventions decay;
+  mechanical enforcement was the whole point.
+- **A single enforcement tool** — `import-linter` alone cannot express strict
+  public-interface (deny-internals-by-default) isolation for bounded contexts,
+  and `ruff` alone cannot express cross-module layer rules; the layered tools
+  are complementary (design 0005, HEX-30..35).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,6 +35,7 @@ Start from [`template.md`](template.md).
 | [0014](0014-repo-simplification-batch.md) | Repo simplification batch — canonical agent config, skill placement, docs & CI layout (SIMP series) | Accepted |
 | [0015](0015-one-logging-pipeline-two-profiles.md) | One logging pipeline, two front-end profiles (CLI vs web policy) | Accepted |
 | [0016](0016-app-short-name-placeholder.md) | App short name is an obvious placeholder (`acmeapp`), not a brand | Accepted |
+| [0017](0017-hexagonal-core-and-boundary-enforcement.md) | Hexagonal core with mechanical boundary enforcement | Accepted |
 
 ## Note on historical decisions
 

--- a/init/manifest.toml
+++ b/init/manifest.toml
@@ -30,6 +30,7 @@ files = [
   ".github/workflows/manual-pr-security-scan.yml",       # 1x
   ".readthedocs.yaml",                                   # 1x
   "LICENSE",                                             # 1x
+  "docs/adr/0017-hexagonal-core-and-boundary-enforcement.md", # 1x (Deciders)
   "docs/research/0003-init-post-init-analysis.md",       # 1x
   "docs/source/_templates/base.html",                    # 1x
   "docs/source/conf.py",                                 # 2x


### PR DESCRIPTION
## What

Adds **ADR `0017-hexagonal-core-and-boundary-enforcement.md`**, recording the architecturally significant decision that was implemented and merged in #433.

The repo separates `docs/design/` (specs) from `docs/adr/` (decisions); #433 shipped the design spec (`0005`) and the implementation but no ADR. This backfills the decision record, per the `docs/design/README.md` convention that a design doc "may spawn ADRs for its load-bearing decisions."

## The decision recorded

- Structure the core as **ports & adapters (hexagonal)** — a shared in-process library with dependency inversion — and explicitly **not** the CLI-over-HTTP pattern.
- **Enforce boundaries mechanically**: `import-linter` (authoritative, `just check` + pre-push), `tach` (bounded-context isolation), `ruff` TID251 (fast pre-commit framework-bleed guard in `core/`), `ty` (port satisfaction).

Includes Context / Decision / Consequences / Alternatives (per `docs/adr/template.md`), cross-links design `0005` and ADR `0015`, and notes the deferred follow-on work (view-model extraction HEX-15, feature-first reshape).

## Changes
- `docs/adr/0017-hexagonal-core-and-boundary-enforcement.md` (new)
- `docs/adr/README.md` — index row
- `init/manifest.toml` — register the new doc under `author` (it carries the maintainer name in Deciders)

## Validation
Docs-only. `manifest-drift` ok, codespell + editorconfig clean, init tests pass (81).

https://claude.ai/code/session_0166N8Jp4eep9JaamfVbp1bw

---
_Generated by [Claude Code](https://claude.ai/code/session_0166N8Jp4eep9JaamfVbp1bw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an Architecture Decision Record describing a hexagonal (ports & adapters) approach for structuring the system’s core, including mechanical boundary-enforcement guidelines.
  * Updated the ADR index to include the new decision (status: Accepted).
* **Chores**
  * Updated the init configuration to apply author text replacement to the newly added ADR file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->