### PR TITLE
fix(web): do not relay upstream error text in problem detail (SEC-4)

### DIFF
--- a/src/py_launch_blueprint/web/problems.py
+++ b/src/py_launch_blueprint/web/problems.py
@@ -137,11 +137,19 @@ def install_problem_handlers(app: FastAPI) -> None:
     async def handle_py_error(request: Request, exc: PyError) -> JSONResponse:
         status_code = ERROR_STATUS.get(type(exc), 500)
         log.warning("request_failed", error=exc.message, exit_code=int(exc.exit_code))
+        # SEC-4: a bare APIError relays the upstream provider's raw error text —
+        # which can include the constructed upstream URL (via str(exc) in the
+        # adapter's _extract_error) — so it is NOT surfaced to web clients; the
+        # full message is logged server-side above. The not-found subclasses and
+        # other PyErrors only carry app/user-input text, so their detail is safe.
+        detail = (
+            "Upstream service request failed." if type(exc) is APIError else exc.message
+        )
         return problem_response(
             request,
             status_code=status_code,
             title=HTTPStatus(status_code).phrase,
-            detail=exc.message,
+            detail=detail,
         )
 
     @app.exception_handler(StarletteHTTPException)

--- a/tests/web/test_app.py
+++ b/tests/web/test_app.py
@@ -164,7 +164,9 @@ def test_api_error_maps_to_502_problem(client):
     body = response.json()
     assert body["status"] == 502
     assert body["instance"] == "/v1/projects/boom"
-    assert "upstream Py API failed" in body["detail"]
+    # SEC-4: the upstream provider's raw error text is NOT relayed to clients.
+    assert body["detail"] == "Upstream service request failed."
+    assert "upstream Py API failed" not in body["detail"]
 
 
 def test_project_not_found_maps_to_404_problem(client):


### PR DESCRIPTION
## What

Fixes **SEC-4** from the post-merge review of the hexagonal work (#433/#435): the web layer relayed a bare `APIError`'s message — which carries the upstream provider's raw error text, and via the adapter's `str(exc)` fallback can include the constructed upstream URL — verbatim in the 502 `application/problem+json` `detail`.

## Fix

- `web/problems.py` — `handle_py_error` now returns a generic `"Upstream service request failed."` detail for a **bare** `APIError` (502); the full message is still logged server-side. The not-found subclasses (`ProjectNotFoundError`/`WorkspaceNotFoundError`, 404) and other `PyError`s keep their detail, which only echoes app/user-input text. This is the hexagon-correct layering (HEX-14): the core keeps its rich message for the CLI operator + logs; only the web boundary genericizes.
- `tests/web/test_app.py` — the 502 test now asserts the upstream text is **not** relayed (regression test).

## Why this scoping
`type(exc) is APIError` matches only the upstream-relay case; the 404 subclasses (whose detail is just the user's own id/workspace) are unaffected — confirmed by `test_project_not_found_maps_to_404_problem` still asserting `"Project not found"` in the body.

## Validation (local, mirrors CI)
ruff check + format, ty, import-linter (5/5), tach, manifest-drift, codespell, bandit (0 issues), full suite **217 passed / 1 skipped**, init tests **81 passed**.

https://claude.ai/code/session_0166N8Jp4eep9JaamfVbp1bw

---
_Generated by [Claude Code](https://claude.ai/code/session_0166N8Jp4eep9JaamfVbp1bw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error responses from upstream service failures now display generic messages instead of exposing raw error details.

* **Tests**
  * Updated error response handling tests to validate sanitized error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->