### PR TITLE
docs: update stale *_APP_ID references to *_CLIENT_ID

### DIFF
--- a/docs/POST_INIT.md
+++ b/docs/POST_INIT.md
@@ -105,9 +105,9 @@ Add under **Settings → Secrets and variables → Actions** (or org-level).
 
 | Secret | Required by | Needed when | How to get it |
 |---|---|---|---|
-| `RELEASE_PLEASE_APP_ID` + `RELEASE_PLEASE_PRIVATE_KEY` | `release-please.yml` | Using release-please (preferred auth) | Create a GitHub App with **Contents + Pull requests: write**, install it, use its App ID + a generated private key. |
+| `RELEASE_PLEASE_CLIENT_ID` + `RELEASE_PLEASE_PRIVATE_KEY` | `release-please.yml` | Using release-please (preferred auth) | Create a GitHub App with **Contents + Pull requests: write**, install it, use its Client ID (e.g. `Iv23li...`) + a generated private key. |
 | `RELEASE_PLEASE_APP_TOKEN` | `release-please.yml` | release-please fallback (instead of the App) | Fine-grained PAT with **Contents + Pull requests: write**. |
-| `CONTRIBUTORS_PLEASE_APP_ID` + `CONTRIBUTORS_PLEASE_PRIVATE_KEY` + `CONTRIBUTORS_PLEASE_PAT` | `update-contributors.yml` | Using contributors automation | From the contributors-please GitHub App install (+ a PAT). |
+| `CONTRIBUTORS_PLEASE_CLIENT_ID` + `CONTRIBUTORS_PLEASE_PRIVATE_KEY` + `CONTRIBUTORS_PLEASE_PAT` | `update-contributors.yml` | Using contributors automation | From the contributors-please GitHub App install — use its Client ID (e.g. `Iv23li...`) + a generated private key (+ a PAT). |
 | `SAFETY_API_KEY` | `manual-pr-security-scan.yml` | Using the manual Safety review | A Safety (safetycli.com) account API key. |
 | `CODECOV_TOKEN` | `ci.yml` upload | **Private repos only** (public repos upload tokenless via OIDC) | From the repo page on codecov.io. |
 
@@ -223,10 +223,10 @@ Replace `<owner>/<repo>` throughout; `gh` must be authenticated with repo admin.
 List what's present with `gh secret list -R <owner>/<repo>`, then set each one
 you need (`gh secret set NAME -R <owner>/<repo>` prompts for the value).
 
-- [ ] **`RELEASE_PLEASE_APP_ID` + `RELEASE_PLEASE_PRIVATE_KEY`** (or the
+- [ ] **`RELEASE_PLEASE_CLIENT_ID` + `RELEASE_PLEASE_PRIVATE_KEY`** (or the
       `RELEASE_PLEASE_APP_TOKEN` PAT) · *secret* — if keeping release-please.
-  - Set: `gh secret set RELEASE_PLEASE_APP_ID …` / `… RELEASE_PLEASE_PRIVATE_KEY < key.pem`
-- [ ] **`CONTRIBUTORS_PLEASE_APP_ID` + `_PRIVATE_KEY` + `_PAT`** · *secret* — if
+  - Set: `gh secret set RELEASE_PLEASE_CLIENT_ID …` / `… RELEASE_PLEASE_PRIVATE_KEY < key.pem`
+- [ ] **`CONTRIBUTORS_PLEASE_CLIENT_ID` + `_PRIVATE_KEY` + `_PAT`** · *secret* — if
       keeping contributors automation.
 - [ ] **`SAFETY_API_KEY`** · *environment secret* — if keeping the manual scan;
       scope it to the `security-review` environment:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -40,7 +40,7 @@ of these two mechanisms instead:
 
 1. **GitHub App (preferred).** Create a GitHub App with **Contents** and
    **Pull requests: write**, install it on this repo, then add two secrets:
-   - `RELEASE_PLEASE_APP_ID` — the App's numeric ID
+   - `RELEASE_PLEASE_CLIENT_ID` — the App's Client ID (e.g. `Iv23li...`)
    - `RELEASE_PLEASE_PRIVATE_KEY` — the App's private key (`.pem` contents)
 
    Both jobs mint a short-lived installation token from these.

--- a/docs/superpowers/plans/2026-06-12-template-press-bootstrap-dogfood.md
+++ b/docs/superpowers/plans/2026-06-12-template-press-bootstrap-dogfood.md
@@ -290,8 +290,8 @@ Log the coupling observation against PF-5 in Problems + matrix.
 - [ ] **Step 2: Set release-please + contributors secrets via the
   repo-secrets skill** — invoke skill `repo-secrets` with args
   `smorinlabs/blueprint-dryrun` (both apps, values from 1Password).
-  Expected: `RELEASE_PLEASE_APP_ID`, `RELEASE_PLEASE_PRIVATE_KEY`,
-  `CONTRIBUTORS_PLEASE_APP_ID`, `CONTRIBUTORS_PLEASE_PRIVATE_KEY`,
+  Expected: `RELEASE_PLEASE_CLIENT_ID`, `RELEASE_PLEASE_PRIVATE_KEY`,
+  `CONTRIBUTORS_PLEASE_CLIENT_ID`, `CONTRIBUTORS_PLEASE_PRIVATE_KEY`,
   `CONTRIBUTORS_PLEASE_PAT` set.
 
 - [ ] **Step 3: Verify + check app installation coverage**


### PR DESCRIPTION
## Summary
- actions/create-github-app-token@v3 deprecated `app-id` in favor of `client-id`. Workflows migrated earlier; this updates the docs that still referenced the legacy secret name.
- Updates `docs/RELEASE.md`, `docs/POST_INIT.md`, and a superpowers plan doc to reference `RELEASE_PLEASE_CLIENT_ID` / `CONTRIBUTORS_PLEASE_CLIENT_ID` and describe the value as a Client ID (e.g. `Iv23li...`) rather than a numeric App ID.
- CHANGELOG.md historical entries intentionally left unchanged.

## Test plan
- [x] grep confirms zero `*_APP_ID` references outside CHANGELOG
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub App setup guides to reflect new secret naming conventions: `RELEASE_PLEASE_CLIENT_ID` and `CONTRIBUTORS_PLEASE_CLIENT_ID` now replace the previous `*_APP_ID` format across release-please and contributors-please automation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->