### PR TITLE
feat(lsp): enable official Astral ty language server for Claude Code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "astral-sh": {
+      "source": {
+        "source": "github",
+        "repo": "astral-sh/claude-code-plugins"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "astral@astral-sh": true
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,27 @@ Allowed types: `feat`, `fix`, `perf`, `refactor`, `revert`, `deps`, `chore`,
 - Build backend: `uv_build` with static `[project] version` (per ADR-06)
 - IDE: VS Code with Ruff, Pyright, EditorConfig extensions
 
+### Python LSP for Claude Code
+
+Python code intelligence for Claude Code comes from the **official Astral
+plugin** (`astral@astral-sh`), enabled by default for this repo in
+`.claude/settings.json` (which also registers the `astral-sh` marketplace,
+`github.com/astral-sh/claude-code-plugins`). The plugin ships a `ty` language
+server (`uvx ty@latest server`) plus `/astral:` skills for uv, ty, and ruff.
+
+`ty` is this repo's type-check authority (ADR-03), so its LSP diagnostics —
+which the plugin leaves **on** by default — agree with what CI gates on rather
+than introducing a second, divergent type-checker voice. No separate binary
+install is needed: `uvx` is provided by `uv`, already in the toolchain.
+
+Activation: collaborators are prompted to install from the `astral-sh`
+marketplace after they accept the workspace-trust dialog; the LSP server starts
+only once the workspace is trusted. Run `/reload-plugins` (or restart) to pick
+it up in an existing session.
+
+Note: the LSP runs `ty@latest` via `uvx`, which can drift from the `ty` version
+pinned in the dev group that CI uses (`uv run ty`); treat CI as authoritative.
+
 ## Releases
 
 `release-please` opens a release PR on every push to `main`; merging the PR


### PR DESCRIPTION
## What

Wires Astral's official Claude Code plugin (`astral@astral-sh`) into the repo so Claude Code gets Python code intelligence from a **`ty` language server** (`uvx ty@latest server`), plus `/astral:` skills for uv, ty, and ruff.

- Registers the `astral-sh` marketplace (`github.com/astral-sh/claude-code-plugins`) and enables `astral@astral-sh` **by default at project scope** in `.claude/settings.json` — collaborators are prompted to install on workspace trust.
- Documents it in `AGENTS.md` under "Python LSP for Claude Code".

## Why `ty` (not Pyright)

`ty` is this repo's type-check authority (ADR-03). Using the `ty` LSP means its diagnostics **agree with what CI gates on**, instead of introducing a second, divergent type-checker voice. No separate binary install is needed — `uvx` is provided by `uv`, already in the toolchain.

## Verification

Exercised the live `ty` LSP against `core/models.py`:
- `documentSymbol` — full class/method/field tree
- `goToDefinition` — `rich_link` -> `core/format.py:73:5` (cross-file)
- `hover` — class signature + docstring
- `findReferences` — 13 references across 3 files
- `astral:ruff` skill loads from the plugin cache

(First LSP call after a reload pays a one-time `uvx` boot; retry-once is expected.)

## Caveat

The LSP runs `ty@latest` via `uvx`, which can drift from the `ty` version pinned in the dev group that CI uses (`uv run ty`). CI remains authoritative — noted in `AGENTS.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Python Language Server Protocol (LSP) support via Astral plugin for enhanced Python development experience with improved code intelligence.

* **Documentation**
  * Added documentation explaining Python LSP configuration, activation after workspace trust, and integration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->