### PR TITLE
ci(release-please): set descriptive PR title pattern

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "a58f62dd4fa9c37ad84146dd9e03e5ce938749b1",
+  "pull-request-title-pattern": "chore(release): publish v${version} — review and merge to ship to PyPI",
   "packages": {
     ".": {
       "release-type": "python",


### PR DESCRIPTION
## Summary
Adds `pull-request-title-pattern` to `release-please-config.json` so the release PR title states the consequence of merging.

```diff
 {
   "$schema": "...",
   "bootstrap-sha": "a58f62dd...",
+  "pull-request-title-pattern": "chore(release): publish v\${version} — review and merge to ship to PyPI",
   "packages": { ... }
 }
```

## Before / after

| | |
|---|---|
| Before | `chore(main): release 2.3.0` |
| After  | `chore(release): publish v2.3.0 — review and merge to ship to PyPI` |

## Why
- **Reviewer signal**: title explicitly names the side-effect (PyPI publish) rather than leaving the reviewer to recall what `chore(main): release X.Y.Z` does.
- **Accidental-merge protection**: a maintainer scanning a busy inbox is less likely to auto-merge if the title says "publish to PyPI".
- **Search affordance**: searching closed PRs for `publish v` finds every release; the old format collides with non-release chores.
- **Commit history**: the squash-commit inherits the title, so `git log --oneline` reads as a publish log too.
- **Zero functional change**: tags, CHANGELOG entries, version bumps, downstream workflow triggers — all unchanged.

Matches the wording already in use in [doxa-research's release-please-config.json](https://github.com/smorin/doxa-research/blob/main/release-please-config.json).

## Test plan
- [x] JSON validates
- [x] Pre-commit hooks pass (gitleaks, codespell, editorconfig-checker, ruff, commitlint)
- [ ] CI green
- [ ] On the next push to main, the existing release PR's title updates to the new pattern (release-please updates titles in place)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration to standardize the formatting of automated release pull request titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->