### PR TITLE
docs: require conventional commit syntax for all commits and pr titles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,14 @@ Conventional Commits with lowercase subject (commitlint enforces):
 Allowed types: `feat`, `fix`, `perf`, `refactor`, `revert`, `deps`, `chore`,
 `docs`, `style`, `test`, `ci`, `build`.
 
+This format is REQUIRED for **every** commit AND **every** PR title — no
+exceptions for bot or autofix commits (e.g. Copilot's "Potential fix…") or
+for squash-merge titles (which default to the PR title). The required
+`commitlint (humans)` CI check lints every non-merge commit in a PR, so one
+non-conventional commit or PR title blocks the merge. Before merging: reword
+any non-conventional commit (or squash the PR), and always set a conventional
+commit title when squash-merging.
+
 ## Code style
 
 - Line length: 88 characters (Black standard)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,13 +115,14 @@ Conventional Commits with lowercase subject (commitlint enforces):
 Allowed types: `feat`, `fix`, `perf`, `refactor`, `revert`, `deps`, `chore`,
 `docs`, `style`, `test`, `ci`, `build`.
 
-This format is REQUIRED for **every** commit AND **every** PR title — no
-exceptions for bot or autofix commits (e.g. Copilot's "Potential fix…") or
-for squash-merge titles (which default to the PR title). The required
-`commitlint (humans)` CI check lints every non-merge commit in a PR, so one
-non-conventional commit or PR title blocks the merge. Before merging: reword
-any non-conventional commit (or squash the PR), and always set a conventional
-commit title when squash-merging.
+This format is REQUIRED for **every** commit — no exceptions for bot or
+autofix commits (e.g. Copilot's "Potential fix…"). The required
+`commitlint (humans)` CI check lints every non-merge commit in a PR, so a
+single non-conventional commit blocks the merge; reword it (or squash the PR)
+before merging. PR titles must follow the format too: commitlint does not
+lint the title itself, but it becomes the default squash-merge commit
+subject, so a non-conventional title lands a non-conventional commit on the
+trunk. Always set a conventional title when squash-merging.
 
 ## Code style
 


### PR DESCRIPTION
## What

Extends the **Commit message format** section in `AGENTS.md` to state explicitly that Conventional Commits syntax is required for **every commit and every PR title** — including bot/autofix commits and squash-merge titles.

## Why

During this batch of merges, Copilot's autofix commit (`Potential fix for pull request finding`) failed the required `commitlint (humans)` check and blocked the PR. This codifies that no commit or PR title is exempt, and notes the practical fix (reword or squash + conventional squash title).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidelines to enforce conventional commit format for all commits and PR titles
  * Clarified that CI will block merges for non-conforming commits or titles
  * Added guidance for rewording non-conforming commits and setting proper titles during squash-merges

<!-- end of auto-generated comment: release notes by coderabbit.ai -->