### PR TITLE
chore: ignore riptide task artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ node_modules/
 # Blueprint init system — local opt-out sentinel (silences the setup guard for
 # blueprint maintainers/contributors). NEVER committed; per-developer.
 init/.blueprint-contributor
+
+# Riptide artifacts (cloud-synced)
+.humanlayer/tasks/


### PR DESCRIPTION
`.humanlayer/tasks/` holds cloud-synced Riptide task artifacts — per-developer
working state that must never be committed. This mirrors the existing
per-developer sentinel convention directly above it in `.gitignore`
(`init/.blueprint-contributor`).

Found during a repo-wide cleanup audit: the directory existed locally and
untracked, and was the only uncommitted change in the working tree.

## Test plan
- `.gitignore`-only change; no runtime surface.
- Pre-commit hooks passed locally (gitleaks, editorconfig-checker, codespell, large-files, commitlint).

https://claude.ai/code/session_01LofznnYN8nzosMxjufg2z4

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/smorinlabs/codesmith/py-launch-blueprint/pr/466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786775395&installation_id=142839762&pr_number=466&repository=smorinlabs%2Fpy-launch-blueprint&return_to=https%3A%2F%2Fgithub.com%2Fsmorinlabs%2Fpy-launch-blueprint%2Fpull%2F466&signature=a6bf43822c6474b005f5a74aefe4c5dfa23d48481878cd8ddf7bfafdd75a9372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project exclusions to prevent Riptide task artifacts from appearing as untracked files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->