### PR TITLE
chore(contributors): ignore blacksmith-sh[bot]

### DIFF
--- a/.contributors.yml
+++ b/.contributors.yml
@@ -18,6 +18,7 @@ ignore:
   - github-actions[bot]
   - dependabot[bot]
   - release-please-smorinlabs[bot]
+  - blacksmith-sh[bot]
 
 classification:
   categories:


### PR DESCRIPTION
`blacksmith-sh[bot]` is the Blacksmith CI runner app, not a project contributor.
It earned a commit during the Blacksmith runner migration and was picked up into
`.contributors.jsonl` as a "Documentation Contributor".

Every other bot is already ignored — `Copilot`, `claude`, `github-actions[bot]`,
`dependabot[bot]`, `release-please-smorinlabs[bot]`. This restores that invariant.

## Why this matters — it unblocks #457

#457 currently carries a real defect that its own CI cannot see:

| File | `blacksmith-sh[bot]` present? |
|---|---|
| `.contributors.jsonl` | yes |
| `.contributors.yml` ignore list | **no** |
| `CONTRIBUTORS.md` | no |

`tests/meta/test_contributors_render.py::test_rendered_contributors_block_matches_state_and_ignore_config`
builds the expected block from every **non-ignored** state record, so the rendered
block cannot match. The Codex review bot flagged this on #457 (P1 + P2) and it is
correct.

**#457's CI is green only because the test matrix is `skipped`** — the path filter
sees a data-only change (`.jsonl` + `.md`, no Python), so the very test that catches
this never runs. Merging #457 as-is would leave `main` with a failing test that the
next code PR would trip over and be blamed for.

## Verification

Applied this exact change against #457's head (`3896ff7`) in a scratch worktree:

```
BEFORE: FAILED tests/meta/test_contributors_render.py::test_rendered_..._ignore_config
AFTER:  1 passed
```

## Test plan
- Config-only change (one line in `.contributors.yml`); no runtime surface.
- Once merged, contributors-please regenerates #457 against the updated ignore list and the test passes.

https://claude.ai/code/session_01LofznnYN8nzosMxjufg2z4

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/smorinlabs/codesmith/py-launch-blueprint/pr/467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786777751&installation_id=142839762&pr_number=467&repository=smorinlabs%2Fpy-launch-blueprint&return_to=https%3A%2F%2Fgithub.com%2Fsmorinlabs%2Fpy-launch-blueprint%2Fpull%2F467&signature=35cc8f29245916d13e63797413c1d6bc35866458426bc2ea42626df794d51ec7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->