### PR TITLE
refactor: remove dead cocogitto recipes and references

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -490,50 +490,6 @@ verify-commits start="HEAD~10" end="HEAD":
 # - release-please opens version-bump PRs automatically (ADR-05).
 # - Use `git commit -m "feat: ..."` directly; commitlint enforces format.
 
-# Install COG (Cocogitto) for changelog and commit management
-[group('install'), group('releases')]
-install-cog:
-    echo "Installing Cocogitto (cog)..."
-    case "$(uname -s)" in \
-    Linux*) \
-        if command -v cargo >/dev/null 2>&1; then \
-            cargo install --force cocogitto; \
-        else \
-            echo "{{YELLOW}}Please install Rust's cargo to install cog{{NC}}"; \
-            echo "Visit https://www.rust-lang.org/tools/install"; \
-        fi \
-        ;; \
-    Darwin*) \
-        if command -v brew >/dev/null 2>&1; then \
-            brew install cocogitto; \
-        else \
-            echo "{{YELLOW}}Please install Homebrew to install cog{{NC}}"; \
-            echo "Visit https://brew.sh/"; \
-        fi \
-        ;; \
-    CYGWIN*|MINGW*|MSYS*|Windows*) \
-        echo "{{YELLOW}}On Windows, please install from https://github.com/cocogitto/cocogitto/releases{{NC}}"; \
-        ;; \
-    *) \
-        echo "{{RED}}Unknown OS, please install manually from https://github.com/cocogitto/cocogitto{{NC}}"; \
-        ;; \
-    esac
-    command -v cog >/dev/null 2>&1 && echo "{{GREEN}}✓{{NC}} Cocogitto installed successfully" || echo "{{RED}}✗{{NC}} Failed to install Cocogitto"
-
-# Check if COG is installed and setup pre-commit hook for commit message verification
-[group('setup'), group('pre-commit')]
-setup-cog-hooks:
-    command -v cog >/dev/null 2>&1 || { echo "{{RED}}Error: Cocogitto (cog) is not installed{{NC}}"; just install-cog; }
-    cog install-hook commit-msg
-    echo "{{GREEN}}✓{{NC}} Commit message hook installed"
-
-# Generate the changelog locally
-[group('releases')]
-changelog:
-    command -v cog >/dev/null 2>&1 || { echo "{{RED}}Error: Cocogitto (cog) is not installed{{NC}}"; exit 1; }
-    cog changelog > CHANGELOG.md
-    echo "{{GREEN}}✓{{NC}} CHANGELOG.md updated"
-
 # Install gitleaks for local secret scanning
 [group('setup'), group('install'), group('pre-commit')]
 install-gitleaks:

--- a/docs/source/reference/configuration_files.md
+++ b/docs/source/reference/configuration_files.md
@@ -13,13 +13,3 @@ The `.pre-commit-config.yaml` file is used to configure pre-commit hooks. These 
 ## [tool.pyright] (in pyproject.toml)
 
 The `[tool.pyright]` section of `pyproject.toml` configures the Pyright static type checker. It specifies settings such as included and excluded directories, defined constants, the Python version to target, and various reporting options for type-related issues. This section allows you to customize how strictly Pyright checks your code for type errors. See [pyproject.toml](https://github.com/smorinlabs/py-launch-blueprint/blob/main/pyproject.toml) for more details.
-
-## cog.toml
-
-The `cog.toml` file configures the `cog` tool, which is used to generate changelog content locally and validate changelog generation in CI. It defines settings such as:
-
-- **Changelog Path**: Defines the generated changelog file.
-- **Remote Links**: Links changelog entries to the GitHub repository.
-- **Author Mapping**: Maps local git signatures to GitHub usernames for changelog links.
-
-Contributor list updates are handled by `smorinlabs/contributors-please-action` and `.contributors.yml`; `cog.toml` is only used for changelog generation.

--- a/docs/source/reference/project_structure.md
+++ b/docs/source/reference/project_structure.md
@@ -82,7 +82,6 @@ py-launch-blueprint/
 │   ├── core/                       # Library: logic + Pydantic models
 │   └── web/                        # FastAPI web service (behind the `web` extra)
 ├── pyproject.toml                  # Project configuration file
-├── cog.toml                        # Cog configuration file
 ├── CONTRIBUTORS.md                 # Project contributors
 ├── README.md                       # Project overview and navigation
 ├── SECURITY.md                     # Security policy
@@ -165,9 +164,6 @@ Template for pull requests to ensure consistency and completeness.
 ### pyproject.toml
 
 Configuration file for the project, including dependencies and build settings.
-
-### cog.toml
-Configuration file for COG (Cocogitto), used for changelog generation.
 
 ### CONTRIBUTORS.md
 Auto-generated file that lists the project contributors.

--- a/docs/source/tools/taplo.md
+++ b/docs/source/tools/taplo.md
@@ -1,7 +1,7 @@
 # Taplo: A Fast TOML Formatter & Linter
 
 ## Introduction
-Taplo is used to automatically format and validate project files like pyproject.toml and cog.toml, ensuring consistent structure and preventing syntax errors across the codebase.
+Taplo is used to automatically format and validate project files like pyproject.toml and tach.toml, ensuring consistent structure and preventing syntax errors across the codebase.
 
 ---
 

--- a/init/init-spec.md
+++ b/init/init-spec.md
@@ -251,7 +251,7 @@ any error (CI-usable).
   year and owner consistent across `LICENSE` / `pyproject.toml` / `conf.py`.
 
 **Environment checks:**
-- Required tools on PATH: `just`, `uv`, `git`, `bun`, `lefthook`, `gitleaks`, `cog`.
+- Required tools on PATH: `just`, `uv`, `git`, `bun`, `lefthook`, `gitleaks`.
 - Project installed (`uv sync` done / venv present / CLI importable).
 - Git hooks installed (lefthook); `origin` configured; Python ≥ 3.12.
 

--- a/init/init_doctor.py
+++ b/init/init_doctor.py
@@ -289,7 +289,7 @@ def run_migration_checks() -> list[Finding]:
 # Environment checks
 # ──────────────────────────────────────────────────────────────
 
-REQUIRED_TOOLS = ("just", "uv", "git", "bun", "lefthook", "gitleaks", "cog")
+REQUIRED_TOOLS = ("just", "uv", "git", "bun", "lefthook", "gitleaks")
 
 
 def check_tool(name: str) -> Finding:


### PR DESCRIPTION
Removes the three remaining Cocogitto (`cog`) recipes from the Justfile:
`install-cog`, `setup-cog-hooks`, and `changelog`.

## Why

Cocogitto is no longer used anywhere in the project:
- No `.cog.toml` exists.
- No workflow, hook, or script references `cog`.
- **Changelog + version bumps** are owned by **release-please** (ADR-05).
- **Commit-message enforcement** is handled by **commitlint** via lefthook (ADR-01, ADR-04).

These recipes were the leftovers of an earlier, partial cog retirement (the
version-bump/create-commit recipes were removed in ITM-044; these three survived
the cull).

## Scope note — why `changelog` is included

The original ask named only `install-cog` + `setup-cog-hooks`. I included the
`changelog` recipe because it is part of the same dead cluster: it shells out to
`cog changelog` — an **uninstallable** tool once `install-cog` is gone — to
regenerate a `CHANGELOG.md` that **release-please already maintains**. Removing
two of the three would leave `changelog` as a broken orphan.

The ITM-044 guidance comment above the block is **retained** — it still accurately
documents what replaced the cog workflow.

## Verification

- `just --summary` parses cleanly (exit 0); the three recipes no longer appear (56 → 53 recipes).
- No remaining `cog` references in the Justfile except the historical ITM-044 comment.
- Dangling-reference sweep: nothing outside the removed block referenced these recipes (workflows, hooks, scripts, docs).
- `tests/meta/test_justfile.py` passes.
- Historical `CHANGELOG.md` mentions of cog are left untouched (they are auto-generated release history, not references).

https://claude.ai/code/session_01LofznnYN8nzosMxjufg2z4

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/smorinlabs/codesmith/py-launch-blueprint/pr/468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786810319&installation_id=142839762&pr_number=468&repository=smorinlabs%2Fpy-launch-blueprint&return_to=https%3A%2F%2Fgithub.com%2Fsmorinlabs%2Fpy-launch-blueprint%2Fpull%2F468&signature=3170418163b3f32de3ed142abf1cd3ce87de78b27e209051e8de55c176cf3b9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed obsolete Cocogitto (COG) tooling recipes from the project automation.
  * Updated contributor documentation to remove `cog.toml` from the project structure and reference materials.
  * Adjusted tool guidance to reference `tach.toml` instead of `cog.toml`.
  * Updated the initialization “required tools” checks to stop including Cocogitto (`cog`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Scope expanded (Copilot review)

A Copilot review flagged that `cog` was still referenced outside the Justfile. Validated and fixed in-PR (d0372e5): removed `cog` from `init/init_doctor.py` `REQUIRED_TOOLS` (a latent bug — it required a tool no provisioner installs) and `init-spec.md`, and corrected the docs describing a non-existent `cog.toml` (`configuration_files.md`, `project_structure.md`, `taplo.md`). The dated research doc keeps its historical mention.
