### PR TITLE
docs(agents): make the PR review-comment merge guard explicit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,21 +88,37 @@ workflow enforce it).
    no-ops — do NOT push until you have either installed it or run the
    step-3 checks manually.
 
-## Pull request review comments
+## Pull request review comments — MERGE GUARD (hard, enforced)
 
-Before merging ANY PR, every review comment must be validated against the actual
-code/docs and then either fixed-and-resolved or replied-to-and-resolved (or
-dismissed) — none may be left dangling. For each comment (human or bot —
-Copilot, CodeRabbit, etc.):
+**This is a hard gate, not a guideline.** This repo has an active ruleset
+("CodeQL & PR Enforcement") with `required_review_thread_resolution: true`, so
+**a PR with ANY unresolved review thread CANNOT be merged — GitHub blocks it.**
+A PR will sit silently `blocked` on a single dangling bot thread. (Do not be
+misled by classic branch protection reporting
+`required_conversation_resolution: false` — the *ruleset* is the real enforcer;
+verify with `gh api "repos/<owner>/<repo>/rulesets"`.)
 
-- Analyze it against the actual code/docs to decide whether it is valid.
-- If valid, fix the underlying issue and mark the thread resolved.
-- If invalid or intentional, reply with the rationale and resolve (or
-  dismiss) the thread.
+Because of this guard, treat review comments as blocking work that must be kept
+current **before opening a PR and continuously while it is open** — bots
+(Copilot, CodeRabbit, Codex, Greptile, …) re-review on every push and add fresh
+threads, so a PR that was clean can become blocked again after a commit.
 
-Purely informational bot comments (e.g. the dependency-review ✅ summary)
-need no action. Do not merge a PR while it still has unresolved actionable
-threads.
+For **every** review comment (human or bot), do all three steps — never skip to
+merge:
+
+1. **Pre-validate** it against the actual code/docs — decide valid or invalid.
+   Do not take a comment (especially a bot's) at face value; confirm it.
+2. **Reply** with a comment recording the verdict and the action taken:
+   - valid → fix the underlying issue *in the PR*, then reply noting the fix;
+   - invalid or intentional → reply with the concrete rationale.
+3. **Resolve** the thread — always, after step 2. Resolving requires the GraphQL
+   `resolveReviewThread` mutation; there is no REST equivalent, so a GraphQL
+   rate-limit (common on some machines) can block *resolution* even when the PR
+   is otherwise green. Plan for that; do not merge around it.
+
+Only purely informational bot comments (e.g. the dependency-review ✅ summary)
+need no action. Never merge — and never assume a PR is mergeable — while any
+actionable thread is unresolved.
 
 ## Commit message format
 


### PR DESCRIPTION
Makes the PR review-comment **merge guard** explicit in the canonical agent
guidance (`AGENTS.md`, which `CLAUDE.md` imports).

## Why

This repo's active ruleset **"CodeQL & PR Enforcement"** sets
`required_review_thread_resolution: true`, so **any unresolved review thread
hard-blocks the merge**. This is easy to miss because classic branch protection
reports `required_conversation_resolution: false` — the *ruleset* is the real
enforcer. A PR can sit silently `blocked` on a single dangling bot thread.

The previous wording treated comment resolution as a soft "before merging"
guideline. This rewrite states it as the hard gate it actually is, and adds:

- **pre-validate → reply with verdict + action → resolve**, for every comment
  (human or bot), never taking a bot comment at face value;
- keep threads current **before opening a PR and continuously while it's open**
  (bots re-review on every push and add fresh threads);
- resolution is **GraphQL-only** (`resolveReviewThread`), so a GraphQL
  rate-limit can block resolution even when the PR is otherwise green.

## Test plan

- Docs-only change to `AGENTS.md`.
- `init/ci/check_manifest_drift.py` passes (the `<owner>/<repo>` placeholder
  avoids introducing an unregistered `owner` identity literal).

https://claude.ai/code/session_01LofznnYN8nzosMxjufg2z4

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/smorinlabs/codesmith/py-launch-blueprint/pr/471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786838893&installation_id=142839762&pr_number=471&repository=smorinlabs%2Fpy-launch-blueprint&return_to=https%3A%2F%2Fgithub.com%2Fsmorinlabs%2Fpy-launch-blueprint%2Fpull%2F471&signature=80acffc8617ffe46cd4ed0626937d7f2723ff5151cce7a4a6c04df765a81a8b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified pull request review requirements, including mandatory resolution of all actionable review threads before merging.
  * Added step-by-step guidance for validating, addressing, replying to, and resolving review comments.
  * Clarified that purely informational bot comments do not require action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->