### PR TITLE
ci: switch dependabot python ecosystem from pip to uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Dependabot config (ITM-061 pip + ITM-062 actions + ITM-043 npm).
+# Dependabot config (ITM-061 uv + ITM-062 actions + ITM-043 npm).
 # Per ADR-08: grouped updates, 5-day cooldown, template-shaped group names.
 # Schedule day: Monday (decided round 13).
 #
@@ -11,8 +11,8 @@
 
 version: 2
 updates:
-  # ITM-061 - Python (pip) ecosystem.
-  - package-ecosystem: "pip"
+  # ITM-061 - Python (uv) ecosystem (native uv support keeps uv.lock in sync).
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Switches the Python Dependabot block from the `pip` ecosystem to the native `uv` ecosystem, so Dependabot regenerates `uv.lock` alongside `pyproject.toml` and dependency PRs stop failing `uv sync --locked`. Same fix as smorinlabs/template-press#32; native uv support: dependabot/dependabot-core#10478.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/smorinlabs/codesmith/py-launch-blueprint/pr/472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786945390&installation_id=142839762&pr_number=472&repository=smorinlabs%2Fpy-launch-blueprint&return_to=https%3A%2F%2Fgithub.com%2Fsmorinlabs%2Fpy-launch-blueprint%2Fpull%2F472&signature=1089d8c50777ef1abc5fa9421197adb9e8bdc79ad1e2350a42d7cdabc260ead8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->