### PR TITLE
ci: skip claude-code-review on bot-authored PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,10 +12,17 @@ on:
 
 jobs:
   claude-review:
-    # Only run on same-repo PRs. Forked-PR runs don't receive repo secrets, so
-    # CLAUDE_CODE_OAUTH_TOKEN would be empty and the job would error noisily on
-    # every external contributor's PR.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Only run on same-repo, human-authored PRs.
+    #  - Forked-PR runs don't receive repo secrets (CLAUDE_CODE_OAUTH_TOKEN would
+    #    be empty), so they'd error on every external contributor's PR.
+    #  - Bot-authored PRs (release-please, dependabot, …) are mechanical and
+    #    don't need an AI code review; the action also aborts on non-human actors
+    #    ("Workflow initiated by non-human actor …"), which showed as a false red
+    #    check on the v2.4.1 release PR (#470). Skipping is a neutral (non-failing)
+    #    outcome for this non-required job.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.user.type != 'Bot'
 
     runs-on: ${{ vars.RUNNER_UBUNTU || 'ubuntu-latest' }}
     permissions:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,17 +12,21 @@ on:
 
 jobs:
   claude-review:
-    # Only run on same-repo, human-authored PRs.
+    # Only run on same-repo, non-bot PRs.
     #  - Forked-PR runs don't receive repo secrets (CLAUDE_CODE_OAUTH_TOKEN would
     #    be empty), so they'd error on every external contributor's PR.
-    #  - Bot-authored PRs (release-please, dependabot, …) are mechanical and
-    #    don't need an AI code review; the action also aborts on non-human actors
+    #  - Bot-involved PRs (release-please, dependabot, …) are mechanical and don't
+    #    need an AI code review; the action also aborts on non-human actors
     #    ("Workflow initiated by non-human actor …"), which showed as a false red
-    #    check on the v2.4.1 release PR (#470). Skipping is a neutral (non-failing)
+    #    check on the v2.4.1 release PR (#470). Skip when EITHER the PR author OR
+    #    the run's initiator (sender — e.g. a bot pushing a commit to a human's
+    #    PR on `synchronize`) is a bot: the action aborts on the initiator, so
+    #    the author check alone isn't enough. Skipping is a neutral (non-failing)
     #    outcome for this non-required job.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository
       && github.event.pull_request.user.type != 'Bot'
+      && github.event.sender.type != 'Bot'
 
     runs-on: ${{ vars.RUNNER_UBUNTU || 'ubuntu-latest' }}
     permissions:


### PR DESCRIPTION
## Summary

Skip `claude-code-review` on **bot-authored** PRs — the root cause of the false
red check on the v2.4.1 release PR (#470).

**Why:** the Claude review runs on every same-repo PR, but bot PRs
(release-please, dependabot, contributors-please) are mechanical and don't need
an AI *code* review. The action also aborts on non-human actors (*"Workflow
initiated by non-human actor …"*), so those PRs got a **false failure** — not a
token problem (`CLAUDE_CODE_OAUTH_TOKEN` authenticated fine in that run).

**Fix:** gate the job on the PR author's type —
`github.event.pull_request.user.type != 'Bot'`. Bot PRs now **skip** (a neutral,
non-failing outcome for this non-required job); the rest of CI (tests, lint,
CodeQL, typecheck, …) still runs on them.

**Least-privilege:** a blanket bot *skip*, not a bot *allowlist* — no broadening
of who can invoke the action (important on a public repo). `claude.yml` (the
`@claude`-mention responder) is intentionally left unchanged: it's
comment-triggered and never fires on a bot opening a PR.

https://claude.ai/code/session_01QDZHfRaphWYgpLeg3oFy5S

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/smorinlabs/codesmith/py-launch-blueprint/pr/481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787088350&installation_id=142839762&pr_number=481&repository=smorinlabs%2Fpy-launch-blueprint&return_to=https%3A%2F%2Fgithub.com%2Fsmorinlabs%2Fpy-launch-blueprint%2Fpull%2F481&signature=0cf64109fde444835b8d3fffef88b0c53bc5d72a580e6eb83ab3bdde30dea35b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated pull request reviews now run only for human-authored changes submitted from the same repository.
  * Reviews are skipped for forked and bot-generated pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->