### PR TITLE
refactor(types): name idempotency tuples, make OutputMode dispatch exhaustive

### DIFF
--- a/projects/P03-type-precision-uplevel.md
+++ b/projects/P03-type-precision-uplevel.md
@@ -28,15 +28,20 @@ src `ANN401` fell 9→3, the 3 legitimate Click slots `# noqa`'d)** · Tier E (T
 `blanket-ignore-comment = "error"` was **re-added** (it exists in 0.0.61, was
 merely absent in 0.0.39) — now 7 promoted rules. Re-verified `just check` green.
 
-**Deferred this pass** (still open, with reasons):
+**Second pass (2026-07-19):** **T11** (idempotency `NamedTuple`s) and **F04**
+(`assert_never` on `OutputMode` dispatch) landed together — no behavior change;
+ty now proves both `assert_never` branches unreachable, i.e. the exhaustiveness
+guarantee is live. **F02, F03, F05 closed as won't-do** (see Decisions below).
+
+**Still open, with reasons:**
 - **T05** (mode `Literal`s) — ripples to local-variable annotations +
   `_resolve_log_format` needs a narrowing restructure; not a clean mechanical
-  flip. Do next with per-site care.
-- **T11** (idempotency `NamedTuple`s) — contained; skipped only to bound this
-  pass. Low risk when resumed.
+  flip. Do opportunistically, per-site, when next in those files.
 - **T12** (`mutation_options` `ParamSpec`) — verify-and-maybe-revert; wants its
-  own ty + CLI-test loop.
-- **F01–F06** — genuine decisions / larger refactors (see below).
+  own ty + CLI-test loop. Low value (drops one `cast`).
+- **F01** — the highest-value item left, and the one place the repo violates its
+  own AGENTS.md boundary rule. Needs a decision: silent-default vs fail-loud.
+- **F06** — ruff `TC`; only with the `runtime-evaluated-base-classes` guardrail.
 
 ## Audit provenance
 
@@ -105,7 +110,7 @@ merely absent in 0.0.39) — now 7 promoted rules. Re-verified `just check` gree
 - [x] [P03-T09] structlog processors `logger: Any` → `WrappedLogger`.
 - [x] [P03-T10] `cli/main.py` `comp: Any` → drop annotation / `ShellComplete`
       (confirm with one `ty check`).
-- [ ] [P03-T11] `web/idempotency.py` `_Entry` + cache key → `NamedTuple`s.
+- [x] [P03-T11] `web/idempotency.py` `_Entry` + cache key → `NamedTuple`s.
 - [ ] [P03-T12] `mutation_options` → `ParamSpec [**P, R]` (verify ty + CLI tests;
       revert to `cast` if either objects).
 - [x] [P03-TS03] `just check` green; CLI tests pass.
@@ -121,19 +126,57 @@ merely absent in 0.0.39) — now 7 promoted rules. Re-verified `just check` gree
 - [x] [P03-T14] `/healthz -> dict[str,str]` → `Health` BaseModel response_model.
 - [x] [P03-TS05] Regenerate OpenAPI snapshot; `just check` green.
 
-### Deferred follow-ups (documented; NOT executed — need decisions)
+### Deferred follow-ups
 - [ ] [P03-F01] Py-API boundary validation with Pydantic models (Codex C1 /
       Fable F8) — **behavior change** (silent empty-`Project` → fail-loud
-      `APIError`). Design decision.
-- [ ] [P03-F02] Recursive `TomlValue` alias across config read/merge/write (C5-7).
-- [ ] [P03-F03] `global_options` `Concatenate[AppContext, P]` typing (C12) —
-      Fable×Codex disagreement; verify against every decorated command.
-- [ ] [P03-F04] `assert_never` exhaustiveness for `OutputMode` dispatch (F10).
-- [ ] [P03-F05] Optional-OTel `_TraceApi` Protocol (C15).
+      `APIError`). Design decision; **still open**.
+- [-] [P03-F02] Recursive `TomlValue` alias across config read/merge/write (C5-7)
+      — **won't do**; see Decisions below.
+- [-] [P03-F03] `global_options` `Concatenate[AppContext, P]` typing (C12)
+      — **won't do**; see Decisions below.
+- [x] [P03-F04] `assert_never` exhaustiveness for `OutputMode` dispatch (F10).
+- [-] [P03-F05] Optional-OTel `_TraceApi` Protocol (C15)
+      — **won't do**; see Decisions below.
 - [ ] [P03-F06] ruff `TC` rollout: configure
       `flake8-type-checking.runtime-evaluated-base-classes =
       ["pydantic.BaseModel","pydantic_settings.BaseSettings"]`, fix 2 `TC006`
       (quote `cast("F", …)`), review 3 unsafe `TC003`, pass `--no-fix` in audits.
+
+## Decisions — won't do (recorded 2026-07-19)
+
+Recorded so future audits (human or AI) don't re-open them. Common thread: each
+would replace a **truthful** `Any`/`cast` at a boundary with something that is
+unrepresentable, unenforceable, or a maintenance liability.
+
+### F03 — `global_options` → `Concatenate`: won't do
+`global_options` is a *signature-changing* decorator — it consumes ~eleven
+keyword arguments Click injects (`output_mode`, `json_mode`, `verbose`, …) **and**
+prepends an `AppContext` positional. **PEP 612 cannot express that**:
+`Concatenate` adds/removes only *positional* parameters, and `P.kwargs` is
+all-or-nothing, so there is no way to say "consume these named keywords, forward
+the rest." The proposed signature is unrepresentable rather than merely awkward,
+and any attempt collapses back to a `cast`. The existing PEP 695
+`[F: Callable[..., Any]]` + `functools.wraps` + `cast` is the state-of-the-art
+shape for Click decorator stacks. (Fable F9 vs Codex C12 — Fable is correct.)
+
+### F02 — recursive `TomlValue` alias: won't do
+`dict[str, Any]` is the **honest** type here: this layer's job is to round-trip
+arbitrary user TOML *including keys it does not know about*. It is already
+disciplined — every path into the core narrows through `Settings.model_validate`
+within one hop, which is exactly the boundary rule in AGENTS.md. The alias buys
+type-shape *documentation*, not safety (the data still arrives as `Any`; a cast
+bridges it), while touching read/merge/write plumbing.
+**Revisit if** config handling grows logic that inspects nested TOML
+structurally instead of handing it to Pydantic.
+
+### F05 — optional-OTel `_TraceApi` Protocol: won't do
+This is a deliberately invisible optional-extra boundary — OpenTelemetry may not
+be installed at all. Local Protocols would hand-maintain a mirror of an upstream
+API we do not control: when OTel changes shape, the Protocol becomes a lie that
+still type-checks. That trades a truthful `Any` for a stale abstraction, to
+document five attribute accesses in one function. Unlike structlog (which ships
+`WrappedLogger`), OTel provides no alias to adopt, so a comment naming the
+surface used is the right level of investment.
 
 ## Automated Verification
 - `uv run --extra web ty check src/py_launch_blueprint/` passes after every tier.

--- a/src/py_launch_blueprint/cli/output.py
+++ b/src/py_launch_blueprint/cli/output.py
@@ -34,6 +34,7 @@ import subprocess  # nosec B404 — only ever runs the user's own pager
 import sys
 from enum import StrEnum
 from pathlib import Path
+from typing import assert_never
 
 import click
 from rich.console import Console
@@ -152,12 +153,18 @@ class Renderer:
         if self.output_file:
             self._render_to_file(result)
             return
-        if self.mode is OutputMode.JSON:
-            click.echo(result.model_dump_json(indent=2))
-        elif self.mode is OutputMode.MARKDOWN:
-            click.echo(self._to_markdown(result))
-        else:
-            self._render_text_paged(result)
+        # Exhaustive by construction: adding an OutputMode member without
+        # handling it here fails the type check at `assert_never` instead of
+        # silently falling through to text.
+        match self.mode:
+            case OutputMode.JSON:
+                click.echo(result.model_dump_json(indent=2))
+            case OutputMode.MARKDOWN:
+                click.echo(self._to_markdown(result))
+            case OutputMode.TEXT:
+                self._render_text_paged(result)
+            case _:  # pragma: no cover — unreachable while the match is exhaustive
+                assert_never(self.mode)
 
     def _render_text_paged(self, result: CLIResult) -> None:
         """Text mode: pipe through the user's pager when output won't fit.
@@ -197,19 +204,22 @@ class Renderer:
         if self.output_file is None:  # pragma: no cover — guarded by render()
             return
         with self.output_file.open("w", encoding="utf-8") as handle:
-            if self.mode is OutputMode.JSON:
-                handle.write(result.model_dump_json(indent=2) + "\n")
-            elif self.mode is OutputMode.MARKDOWN:
-                handle.write(self._to_markdown(result) + "\n")
-            else:
-                # A file is not a TTY: color only if explicitly "always".
-                file_console = Console(
-                    file=handle,
-                    highlight=False,
-                    force_terminal=(self.color == "always"),
-                    no_color=(self.color != "always"),
-                )
-                self._render_text(result, file_console)
+            match self.mode:
+                case OutputMode.JSON:
+                    handle.write(result.model_dump_json(indent=2) + "\n")
+                case OutputMode.MARKDOWN:
+                    handle.write(self._to_markdown(result) + "\n")
+                case OutputMode.TEXT:
+                    # A file is not a TTY: color only if explicitly "always".
+                    file_console = Console(
+                        file=handle,
+                        highlight=False,
+                        force_terminal=(self.color == "always"),
+                        no_color=(self.color != "always"),
+                    )
+                    self._render_text(result, file_console)
+                case _:  # pragma: no cover — unreachable while the match is exhaustive
+                    assert_never(self.mode)
 
     def _render_text(self, result: CLIResult, console: Console) -> None:
         columns = result.table_columns()

--- a/src/py_launch_blueprint/web/idempotency.py
+++ b/src/py_launch_blueprint/web/idempotency.py
@@ -33,7 +33,7 @@ single-flighted; that also needs the shared store.
 import time
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable
-from typing import override
+from typing import NamedTuple, override
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
@@ -44,10 +44,33 @@ IDEMPOTENCY_HEADER = "idempotency-key"
 REPLAYED_HEADER = "idempotency-replayed"
 _UNSAFE_METHODS = frozenset({"POST", "PUT", "PATCH"})
 
-#: (stored_at_monotonic, status_code, raw_headers, body)
-#: Headers are kept as raw (name, value) pairs — not a dict — so multi-valued
-#: headers (notably Set-Cookie) survive caching and replay intact.
-_Entry = tuple[float, int, list[tuple[bytes, bytes]], bytes]
+
+class _CacheKey(NamedTuple):
+    """What makes two requests "the same" request for replay purposes.
+
+    Four same-typed strings: naming them means a transposed construction
+    (``path`` and ``method`` swapped, say) is a type error instead of a cache
+    that silently shards on the wrong key.
+    """
+
+    method: str
+    path: str
+    query: str
+    idempotency_key: str
+
+
+class _Entry(NamedTuple):
+    """A cached response. This shape is the contract a future Redis-backed
+    store must round-trip, so the fields are named rather than positional.
+
+    Headers are kept as raw (name, value) pairs — not a dict — so multi-valued
+    headers (notably Set-Cookie) survive caching and replay intact.
+    """
+
+    stored_at: float  # time.monotonic() at cache time
+    status_code: int
+    raw_headers: list[tuple[bytes, bytes]]
+    body: bytes
 
 
 class IdempotencyMiddleware(BaseHTTPMiddleware):
@@ -62,7 +85,7 @@ class IdempotencyMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
         self.ttl_seconds = ttl_seconds
         self.max_entries = max_entries
-        self._store: OrderedDict[tuple[str, str, str, str], _Entry] = OrderedDict()
+        self._store: OrderedDict[_CacheKey, _Entry] = OrderedDict()
 
     @override
     async def dispatch(
@@ -75,18 +98,22 @@ class IdempotencyMiddleware(BaseHTTPMiddleware):
         # Query string is part of the key: same Idempotency-Key against
         # /things?a=1 and /things?a=2 are different requests and must not
         # replay each other's responses.
-        cache_key = (request.method, request.url.path, request.url.query, key)
+        cache_key = _CacheKey(
+            method=request.method,
+            path=request.url.path,
+            query=request.url.query,
+            idempotency_key=key,
+        )
         now = time.monotonic()
 
         entry = self._store.get(cache_key)
         if entry is not None:
-            stored_at, status_code, raw_headers, body = entry
-            if now - stored_at < self.ttl_seconds:
+            if now - entry.stored_at < self.ttl_seconds:
                 self._store.move_to_end(cache_key)
-                replay = Response(content=body, status_code=status_code)
+                replay = Response(content=entry.body, status_code=entry.status_code)
                 # Shallow-copy: the marker append below must not leak into
                 # the cached entry and stack up across replays.
-                replay.raw_headers = list(raw_headers)
+                replay.raw_headers = list(entry.raw_headers)
                 replay.headers[REPLAYED_HEADER] = "true"
                 return replay
             del self._store[cache_key]
@@ -109,11 +136,11 @@ class IdempotencyMiddleware(BaseHTTPMiddleware):
         # Only successful outcomes are replayable; errors should be retried
         # for real (the Stripe semantics).
         if 200 <= response.status_code < 300:
-            self._store[cache_key] = (
-                now,
-                response.status_code,
-                list(response.headers.raw),
-                body,
+            self._store[cache_key] = _Entry(
+                stored_at=now,
+                status_code=response.status_code,
+                raw_headers=list(response.headers.raw),
+                body=body,
             )
             while len(self._store) > self.max_entries:
                 self._store.popitem(last=False)

--- a/src/py_launch_blueprint/web/idempotency.py
+++ b/src/py_launch_blueprint/web/idempotency.py
@@ -48,9 +48,12 @@ _UNSAFE_METHODS = frozenset({"POST", "PUT", "PATCH"})
 class _CacheKey(NamedTuple):
     """What makes two requests "the same" request for replay purposes.
 
-    Four same-typed strings: naming them means a transposed construction
-    (``path`` and ``method`` swapped, say) is a type error instead of a cache
-    that silently shards on the wrong key.
+    Four same-typed strings, so naming them does NOT make a transposition a
+    type error — ``str`` is ``str``, and a ``NamedTuple`` still accepts
+    positional construction. What it buys is keyword construction and
+    attribute access at the read sites, so a ``path``/``method`` swap is
+    visible in review rather than hidden behind ``key[1]``. ``_Entry`` below,
+    whose fields differ in type, does get the checked guarantee.
     """
 
     method: str


### PR DESCRIPTION
## Summary

P03 **T11 + F04** — two contained type-precision fixes. **No behavior change.**

### T11 — name the idempotency tuples (`web/idempotency.py`)
- The cache key was `tuple[str, str, str, str]` — **four indistinguishable
  strings**. A transposed construction (`path`/`method` swapped) type-checked
  today and would have **silently sharded the cache on the wrong key**. It's now
  `_CacheKey(method, path, query, idempotency_key)`.
- `_Entry` was a positional tuple whose meaning lived in a comment — despite the
  module docstring calling that shape *"the contract"* a future Redis-backed
  store must round-trip. Now a `NamedTuple` with named fields; call sites use
  attribute access instead of positional unpacking.

### F04 — exhaustive `OutputMode` dispatch (`cli/output.py`)
- `render()` and `_render_to_file()` used `if/elif/else` with text as the
  implicit fallback, so a new `OutputMode` member would **silently render as
  text at both sites**. Both are now `match` statements ending in
  `assert_never`, so adding a mode without handling it **fails the type check**.
- ty confirms the guarantee is live: it proves both default branches
  unreachable.

Relevant to a template repo — "add an output mode" is exactly what a fork does.

### Verification
`ty` ✓ · `ruff check` ✓ · `ruff format --check` ✓ · **241 tests pass**
(including the 8 idempotency tests, which exercise replay/TTL/LRU against the
new NamedTuples).

https://claude.ai/code/session_01QDZHfRaphWYgpLeg3oFy5S

---

### Also: P03 bookkeeping (`docs(p03)` commit)

Marks **T11** and **F04** done, and records **F02 / F03 / F05 as won't-do**
(`[-]`) with rationale, so future audits don't re-open them:

- **F03** (`global_options` → `Concatenate`) — **PEP 612 cannot express**
  "consume these named keywords, forward the rest" (`Concatenate` is
  positional-only; `P.kwargs` is all-or-nothing). Unrepresentable, not merely
  awkward; any attempt collapses back to a `cast`.
- **F02** (recursive `TomlValue` alias) — `dict[str, Any]` is the *honest* type
  for round-tripping arbitrary user TOML incl. unknown keys, and it's already
  narrowed via `Settings.model_validate` within one hop.
- **F05** (optional-OTel Protocol) — hand-mirroring an upstream API we don't
  control turns a truthful `Any` into a stale abstraction that still
  type-checks.

**Still open:** F01 (highest value — the one place the repo violates its own
AGENTS.md boundary rule; needs a silent-default vs fail-loud decision), plus
T05, T12, F06.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved output handling reliability across JSON, Markdown, and text formats.
  - Preserved idempotent response replay behavior while improving consistency for cached responses.

- **Documentation**
  - Updated project progress tracking to record completed type-safety improvements.
  - Clarified remaining follow-ups and documented decisions for deferred items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->