### PR TITLE
docs: trunk uses merge commits, not squash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,11 +134,14 @@ Allowed types: `feat`, `fix`, `perf`, `refactor`, `revert`, `deps`, `chore`,
 This format is REQUIRED for **every** commit — no exceptions for bot or
 autofix commits (e.g. Copilot's "Potential fix…"). The required
 `commitlint (humans)` CI check lints every non-merge commit in a PR, so a
-single non-conventional commit blocks the merge; reword it (or squash the PR)
-before merging. PR titles must follow the format too: commitlint does not
-lint the title itself, but it becomes the default squash-merge commit
-subject, so a non-conventional title lands a non-conventional commit on the
-trunk. Always set a conventional title when squash-merging.
+single non-conventional commit blocks the merge; reword it before merging.
+This matters more under merge commits than it did under squash: the branch's
+individual commits land on the trunk, and release-please parses *those* —
+not the PR title. The merge commit's own subject is left deliberately
+non-conventional (`merge_commit_title=MERGE_MESSAGE`, i.e. `Merge pull
+request #N from …`) precisely so release-please skips it and counts each
+change exactly once. Conventional PR titles are still expected for review
+legibility; they are simply not what the changelog is built from.
 
 ## Code style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,8 +138,8 @@ single non-conventional commit blocks the merge; reword it before merging.
 This matters more under merge commits than it did under squash: the branch's
 individual commits land on the trunk, and release-please parses *those* —
 not the PR title. The merge commit's own subject is left deliberately
-non-conventional (`merge_commit_title=MERGE_MESSAGE`, i.e. `Merge pull
-request #N from …`) precisely so release-please skips it and counts each
+non-conventional (`merge_commit_title=MERGE_MESSAGE`, i.e.
+`Merge pull request #N from …`) precisely so release-please skips it and counts each
 change exactly once. Conventional PR titles are still expected for review
 legibility; they are simply not what the changelog is built from.
 


### PR DESCRIPTION
Repo settings now use `merge_commit_title=MERGE_MESSAGE` so release-please parses the branch's individual commits and skips the merge commit, counting each change exactly once.

https://claude.ai/code/session_01QMXxa6VDYw8JrgYpxvkitE

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/smorinlabs/codesmith/py-launch-blueprint/pr/491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787196048&installation_model_id=425421&pr_number=491&repository=smorinlabs%2Fpy-launch-blueprint&return_to=https%3A%2F%2Fgithub.com%2Fsmorinlabs%2Fpy-launch-blueprint%2Fpull%2F491&signature=ffcc083b23dcd553b55fad789f7af010a058538a0c8892a685131c839be2c3bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->