### PR TITLE
docs(projects): mark P04 complete

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -25,7 +25,7 @@ file by hand — see Conventions.
 | P01 | `[x]` | [Init app-name rebrand robustness](projects/P01-init-rebrand-robustness.md) — per-field drift coverage (B) + derive non-contract internals (C) |
 | P02 | `[x]` | [Repo simplification & organization (SIMP series)](projects/P02-repo-simplification.md) — single-purpose PRs to simplify/consolidate Justfile, docs, setup, tests, workflows, agent configs |
 | P03 | `[~]` | [Type Precision Uplevel](projects/P03-type-precision-uplevel.md) — eliminate leaking/overly-general types + verified ty rule promotions + scoped ruff ANN, from a Fable×Codex two-lens audit |
-| P04 | `[~]` | [Py-API Boundary Validation](projects/P04-py-api-boundary-validation.md) — validate Py-API responses at the edge with Pydantic; silent drift → APIError |
+| P04 | `[x]` | [Py-API Boundary Validation](projects/P04-py-api-boundary-validation.md) — validate Py-API responses at the edge with Pydantic; silent drift → APIError |
 
 ## Conventions
 

--- a/init/manifest.toml
+++ b/init/manifest.toml
@@ -355,7 +355,7 @@ files = [
   "tests/web/test_versioning.py",                      # 1x
   "projects/P01-init-rebrand-robustness.md",           # 1x
   "projects/P03-type-precision-uplevel.md",            # 5x
-  "projects/P04-py-api-boundary-validation.md",        # 1x
+  "projects/P04-py-api-boundary-validation.md",        # 2x
   "research/reference/python-typing-ty-2026-07-18.md", # 1x
   "research/topics/01-python-typing-best-practices/baseline.md", # 1x
   "research/topics/01-python-typing-best-practices/audit-fable.md", # 13x

--- a/projects/P04-py-api-boundary-validation.md
+++ b/projects/P04-py-api-boundary-validation.md
@@ -105,24 +105,31 @@ Confirmed 2026-07-19, before implementation:
       `py_launch_blueprint`, so a fork's `just init` rewrites it rather than
       shipping half-renamed (caught by `check_manifest_drift.py`, as designed).
 - [x] [P04-TS04] PR opened, review threads resolved, merged — #483 (stacked on
-      #482, retargeted to `main` on its merge). Six review findings from four
-      independent bots: five valid and fixed, one refuted with evidence (see
+      #482, retargeted to `main` on its merge). Six review threads from four
+      independent bots: four valid and fixed, two refuted with evidence (see
       Review outcomes).
 
 ## Review outcomes
 
-Greptile, Copilot and Codex independently flagged that the first
-empty-workspace validator (`value if value else None`) absorbed *every* falsy
-value. All three were right, and the reasoning that produced it — "mirror the
-old `or {}` exactly" — was the defect: that old behaviour *is* the silent
-degradation this project removes. Fixed in `e8fb025`; see Decision 2.
+Six threads, four bots. **Four valid** — Greptile (`py_api.py:90`), Copilot
+(`:90` and `:100`) and Codex (`:90`) — all converging on two defects:
 
-`github-code-quality` flagged the `@overload` stub bodies (`...`) as
-"statement has no effect". **Refuted and dismissed as a false positive**: PEP
-484 specifies `...` for overload stubs, and having no effect is the point. An
-AST census of this project's stdlib + site-packages found **722 `...` vs 47
-`pass`** (94%); ruff is neutral between the two, so the suggestion was purely
-stylistic and pointed away from the dominant convention.
+1. The first empty-workspace validator (`value if value else None`) absorbed
+   *every* falsy value. The reasoning that produced it — "mirror the old
+   `or {}` exactly" — was itself the defect: that old behavior **is** the
+   silent degradation this project removes.
+2. `ConfigDict(coerce_numbers_to_str=True)` was model-wide, so a numeric
+   `name` would have been silently stringified.
+
+Both fixed in `e8fb025`; see Decisions 2 and 5.
+
+**Two refuted** — `github-code-quality` (`:155`, `:166`) flagged the
+`@overload` stub bodies (`...`) as "statement has no effect" and suggested
+`pass`. Dismissed as a **false positive**: PEP 484 specifies `...` for overload
+stubs, and having no effect is the point. An AST census of the interpreter's
+standard library plus this project's installed site-packages found **722 `...`
+vs 47 `pass`** (94%); ruff is neutral between the two, so the suggestion was
+purely stylistic and pointed away from the dominant convention.
 
 ## Automated Verification
 

--- a/projects/P04-py-api-boundary-validation.md
+++ b/projects/P04-py-api-boundary-validation.md
@@ -1,6 +1,6 @@
 # P04 — Py-API Boundary Validation
 
-**Status**: `[~]` in progress (v0.1.0)
+**Status**: `[x]` complete (v0.1.0) — merged to `main` 2026-07-20 via #483
 **Goal**: Validate every Py-API response into private Pydantic models at the
 adapter edge, so upstream schema drift raises `APIError` instead of degrading
 into an empty-id `Project` or an empty list that reads to the user as "no
@@ -104,7 +104,25 @@ Confirmed 2026-07-19, before implementation:
 - [x] [P04-T06] Register the project file in `init/manifest.toml` under
       `py_launch_blueprint`, so a fork's `just init` rewrites it rather than
       shipping half-renamed (caught by `check_manifest_drift.py`, as designed).
-- [ ] [P04-TS04] PR opened, review threads resolved, merged.
+- [x] [P04-TS04] PR opened, review threads resolved, merged — #483 (stacked on
+      #482, retargeted to `main` on its merge). Six review findings from four
+      independent bots: five valid and fixed, one refuted with evidence (see
+      Review outcomes).
+
+## Review outcomes
+
+Greptile, Copilot and Codex independently flagged that the first
+empty-workspace validator (`value if value else None`) absorbed *every* falsy
+value. All three were right, and the reasoning that produced it — "mirror the
+old `or {}` exactly" — was the defect: that old behaviour *is* the silent
+degradation this project removes. Fixed in `e8fb025`; see Decision 2.
+
+`github-code-quality` flagged the `@overload` stub bodies (`...`) as
+"statement has no effect". **Refuted and dismissed as a false positive**: PEP
+484 specifies `...` for overload stubs, and having no effect is the point. An
+AST census of this project's stdlib + site-packages found **722 `...` vs 47
+`pass`** (94%); ruff is neutral between the two, so the suggestion was purely
+stylistic and pointed away from the dominant convention.
 
 ## Automated Verification
 


### PR DESCRIPTION
## Summary

Docs only. **P04 merged to `main` via #483**, but the tracker still read `[~]`.
This flips the trunk row and the project status to `[x]` and checks off
`P04-TS04`.

Verified against `main` before claiming completion — the silent-default `.get()`
chains are gone from `core/adapters/py_api.py`, seven validation references are
present, and the only remaining `Any` in that module is a word inside a
docstring.

## Also records the review outcomes

Worth not re-deriving later:

- **Greptile, Copilot and Codex independently** caught that the first
  empty-workspace validator (`value if value else None`) absorbed *every* falsy
  value. All three were right — and the reasoning that produced it, "mirror the
  old `or {}` exactly", was itself the defect: that old behaviour **is** the
  silent degradation P04 set out to remove.
- **`github-code-quality`** flagged the `@overload` stub bodies (`...`) as
  "statement has no effect". Recorded as a **refuted false positive**: PEP 484
  specifies `...` for overload stubs, and having no effect is the point. An AST
  census of this project's stdlib + site-packages found **722 `...` vs 47
  `pass`** (94%), and ruff is neutral between them — so the suggestion was
  purely stylistic and pointed away from the dominant convention.

## Verification

`uv run --script init/ci/check_manifest_drift.py` → ok. The manifest occurrence
comment for this file is bumped `1x` → `2x` to match its actual content.

https://claude.ai/code/session_01QDZHfRaphWYgpLeg3oFy5S

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/smorinlabs/codesmith/py-launch-blueprint/pr/492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787205989&installation_model_id=425421&pr_number=492&repository=smorinlabs%2Fpy-launch-blueprint&return_to=https%3A%2F%2Fgithub.com%2Fsmorinlabs%2Fpy-launch-blueprint%2Fpull%2F492&signature=bf0fff8240a7997416d738ddd2bbd6fc69b3bfb27442664640a154543432fe1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->