### PR TITLE
fix: stop reporting CodeRabbit rate limits as commit-status failures

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -12,6 +12,14 @@ knowledge_base:
 reviews:
   profile: assertive
   request_changes_workflow: false
+  # A reviewer's own quota is not a build failure. When CodeRabbit cannot
+  # review — plan rate limit, transient error — leave the commit status alone
+  # instead of setting it to 'failure'. A red mark that no build produced
+  # misleads humans and merge automation alike: it reads as "the code is
+  # broken" when it means "the reviewer was busy".
+  fail_commit_status: false
+  # Keep the honest signal: 'pending' while reviewing, 'success' when done.
+  commit_status: true
   auto_review:
     enabled: true
   path_instructions:


### PR DESCRIPTION
## Problem

When CodeRabbit cannot review a PR — plan rate limit, transient error — it sets a **commit status to `failure`** with the description *"Review rate limited"*.

That red mark reads as *"the code is broken"* when it actually means *"the reviewer was busy"*. It misleads humans skimming the PR, and it misleads merge automation, which reasonably treats a red check as a CI failure and routes it to a build-debugging path that has nothing to fix.

Observed on **three PRs in one session** across two repos today.

## Change

```yaml
reviews:
  fail_commit_status: false   # reviewer quota ≠ build failure
  commit_status: true         # keep honest pending/success
```

Per the [CodeRabbit configuration reference](https://docs.coderabbit.ai/reference/configuration):

| Key | Default | Controls |
|---|---|---|
| `fail_commit_status` | `false` | commit status → `failure` when CodeRabbit **cannot** review, for any reason |
| `commit_status` | `true` | the normal `pending` → `success` during a real review |

These govern **status reporting only, not review execution** — reviews still run and queue exactly as before.

## What this does *not* fix

It does not raise the quota. A rate-limited PR is still genuinely un-reviewed, and suppressing the red mark alone would leave PRs that *look* reviewed and weren't — arguably worse than the honest-but-misclassified failure.

The intent is narrower and defensible on its own: **stop reporting a reviewer's availability as a property of the code.** The plan limit is a separate, billing-side question.

## Note on the documented default

The reference says `fail_commit_status` already defaults to `false`, yet the failure status is being posted with no `.coderabbit.yaml` present. That points at the org/repo-level dashboard settings as the effective source. Setting it explicitly in-repo makes the intent versioned and reviewable rather than living in a web UI.

https://claude.ai/code/session_01CEi2M1eWUgA4f16z2nhUue

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/smorinlabs/codesmith/py-launch-blueprint/pr/493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787206055&installation_model_id=425421&pr_number=493&repository=smorinlabs%2Fpy-launch-blueprint&return_to=https%3A%2F%2Fgithub.com%2Fsmorinlabs%2Fpy-launch-blueprint%2Fpull%2F493&signature=584dc9d9045caed4ff0943dc3f635b7d93b00e395a055f5ed16cacf508db200c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->