### PR TITLE
fix(release): update uv.lock atomically

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,5 +1,6 @@
 # Release-please workflow (ITM-052 + ITM-053 + ITM-054).
-# Opens release PR on push to main; sync-uv-lock keeps uv.lock current.
+# Opens an internally consistent release PR on push to main; release-please
+# updates pyproject.toml and uv.lock atomically in the generated release commit.
 # Per ADR-05. Auth uses one of two mechanisms that can BOTH open PRs and trigger
 # downstream workflows (publish.yml) — GITHUB_TOKEN is intentionally NOT used as
 # a fallback, since it never triggers downstream workflows and may be blocked
@@ -7,7 +8,7 @@
 #   1. GitHub App (preferred): set RELEASE_PLEASE_CLIENT_ID + RELEASE_PLEASE_PRIVATE_KEY
 #      (App with Contents + Pull requests: write). Client ID is the modern
 #      (non-deprecated) input name for actions/create-github-app-token@v3;
-#      both jobs mint an installation token from these values.
+#      this workflow mints an installation token from these values.
 #   2. Fallback PAT: set RELEASE_PLEASE_APP_TOKEN (fine-grained PAT, Contents +
 #      Pull requests: write).
 # See docs/RELEASE.md for setup. With neither configured, release-please fails fast.
@@ -35,9 +36,6 @@ jobs:
       # Surfaced so the app-token step's `if:` can test it (secrets are not
       # available directly in `if:` conditions). Empty unless the App is set up.
       RP_CLIENT_ID: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
-    outputs:
-      release_created: ${{ steps.rp.outputs.release_created }}
-      pr: ${{ steps.rp.outputs.pr }}
     steps:
       # Mint a GitHub App installation token when the App is configured, so the
       # release PR/tag triggers downstream workflows. Skipped otherwise.
@@ -50,7 +48,6 @@ jobs:
           private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
 
       - name: release-please
-        id: rp
         uses: googleapis/release-please-action@v5.0.0
         with:
           # Minted App installation token (preferred) or the RELEASE_PLEASE_APP_TOKEN
@@ -58,54 +55,3 @@ jobs:
           token: ${{ steps.app-token.outputs.token || secrets.RELEASE_PLEASE_APP_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-  # ITM-054 - sync-uv-lock job. Regenerates uv.lock after release-please bumps
-  # [project] version on the release PR. Contingent on ADR-08 (uv.lock tracked).
-  sync-uv-lock:
-    name: sync-uv-lock
-    needs: release-please
-    if: ${{ needs.release-please.outputs.pr != '' }}
-    runs-on: ${{ vars.RUNNER_UBUNTU || 'ubuntu-latest' }}
-    permissions:
-      contents: write
-      pull-requests: write
-    env:
-      RP_CLIENT_ID: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
-    steps:
-      # Mint a fresh installation token from the same App (a separate token —
-      # steps don't cross jobs) so the uv.lock sync commit pushed to the release
-      # PR branch also triggers its CI checks.
-      - name: Mint release-please app token
-        id: app-token
-        if: ${{ env.RP_CLIENT_ID != '' }}
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
-
-      - name: Checkout release PR branch
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ fromJson(needs.release-please.outputs.pr).headBranchName }}
-          token: ${{ steps.app-token.outputs.token || secrets.RELEASE_PLEASE_APP_TOKEN }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
-
-      - name: Regenerate uv.lock
-        run: uv lock
-
-      - name: Commit if changed
-        env:
-          GIT_AUTHOR_NAME: github-actions[bot]
-          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
-          GIT_COMMITTER_NAME: github-actions[bot]
-          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
-        run: |
-          if ! git diff --quiet uv.lock; then
-            git add uv.lock
-            git commit -m "chore: sync uv.lock"
-            git push
-          else
-            echo "uv.lock already in sync"
-          fi

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -7,13 +7,14 @@ Release flow per ADR-05 + ADR-06 + ADR-07. See
 
 1. Merge `feat:` / `fix:` / `perf:` commits to `main`.
 2. The `release-please` workflow opens (or updates) a release PR
-   proposing the next semver bump + a `CHANGELOG.md` entry.
+   proposing the next semver bump + a `CHANGELOG.md` entry. Its generated
+   commit updates `pyproject.toml` and the editable root entry in `uv.lock`
+   atomically, so the PR is internally consistent from its first revision.
 3. Merge the release PR. release-please pushes a `v*` tag.
 4. The `publish` workflow fires on the tag:
    - `build` job: tag-reachability + version-matches-tag, then `uv build`.
    - `publish-testpypi`: OIDC upload to TestPyPI (env `testpypi`).
    - `publish-pypi`: OIDC upload to PyPI (env `pypi`).
-   - `sync-uv-lock` job (in release-please workflow) keeps `uv.lock` current.
 
 ## Disabling release-please (downstream projects)
 
@@ -43,7 +44,7 @@ of these two mechanisms instead:
    - `RELEASE_PLEASE_CLIENT_ID` — the App's Client ID (e.g. `Iv23li...`)
    - `RELEASE_PLEASE_PRIVATE_KEY` — the App's private key (`.pem` contents)
 
-   Both jobs mint a short-lived installation token from these.
+   The workflow mints a short-lived installation token from these.
 
 2. **Fallback PAT.** Create a fine-grained Personal Access Token scoped to this
    repo with **Contents** and **Pull requests: write**, stored as the

--- a/docs/source/about/design_decisions.md
+++ b/docs/source/about/design_decisions.md
@@ -555,11 +555,15 @@ removes manual, error-prone release bookkeeping.
 `.github/workflows/release-please.yml`; ADR-05 (per AGENTS.md), ITM-052/053/054.
 
 ### Lockfile stays in sync on the release PR
-**What** — a `sync-uv-lock` job regenerates `uv.lock` on the release PR.
-**Why** — the version bump changes package metadata; regenerating the lock on the
-same PR keeps it consistent at the moment of release.
-**Value** — the tagged commit always has a matching lockfile.
-**Refs** — `.github/workflows/release-please.yml`; ITM-054.
+**What** — release-please's TOML updater changes the editable project entry in
+`uv.lock` in the same generated commit that bumps `pyproject.toml`.
+**Why** — a follow-up workflow commit left a window where CI and reviewers saw
+stale locked metadata. Generating both version surfaces atomically removes that
+race while `uv lock --check` remains the independent freshness gate.
+**Value** — every revision of a release PR, including the first, has a matching
+lockfile; no repair commit or force-push is required.
+**Refs** — `release-please-config.json`, `.github/workflows/release-please.yml`;
+ITM-054.
 
 ### Publishing via OIDC Trusted Publishing
 **What** — on a `v*` tag, `publish.yml` verifies the tag is on `main` and that

--- a/init/manifest.toml
+++ b/init/manifest.toml
@@ -390,6 +390,7 @@ files = [
   "AGENTS.md",                                    # 3x
   "Justfile",                                     # 1x
   "README.md",                                    # 17x
+  "release-please-config.json",                   # 1x (uv.lock package selector)
   "docs/design/0001-plbp-cli-conventions.md",     # 3x
   "docs/research/0003-init-post-init-analysis.md", # 4x
   "docs/source/_templates/base.html",             # 1x
@@ -416,6 +417,7 @@ files = [
   "docs/adr/0013-web-service-best-practices.md",  # 1x
   "docs/source/web/index.md",                     # 2x
   "tests/meta/test_codex_astral_plugin.py",       # 2x
+  "tests/meta/test_version_consistency.py",       # 1x (release updater guard)
 ]
 mode = "text"
 

--- a/init/manifest.toml
+++ b/init/manifest.toml
@@ -390,7 +390,6 @@ files = [
   "AGENTS.md",                                    # 3x
   "Justfile",                                     # 1x
   "README.md",                                    # 17x
-  "release-please-config.json",                   # 1x (uv.lock package selector)
   "docs/design/0001-plbp-cli-conventions.md",     # 3x
   "docs/research/0003-init-post-init-analysis.md", # 4x
   "docs/source/_templates/base.html",             # 1x
@@ -417,7 +416,6 @@ files = [
   "docs/adr/0013-web-service-best-practices.md",  # 1x
   "docs/source/web/index.md",                     # 2x
   "tests/meta/test_codex_astral_plugin.py",       # 2x
-  "tests/meta/test_version_consistency.py",       # 1x (release updater guard)
 ]
 mode = "text"
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,7 +16,7 @@
         {
           "type": "toml",
           "path": "uv.lock",
-          "jsonpath": "$.package[?(@.name.value=='py-launch-blueprint' && @.source.editable.value=='.')].version"
+          "jsonpath": "$.package[?(@.source && @.source.editable && @.source.editable.value=='.')].version"
         }
       ],
       "changelog-sections": [

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,6 +12,11 @@
           "type": "toml",
           "path": "pyproject.toml",
           "jsonpath": "$.project.version"
+        },
+        {
+          "type": "toml",
+          "path": "uv.lock",
+          "jsonpath": "$.package[?(@.name.value=='py-launch-blueprint')].version"
         }
       ],
       "changelog-sections": [

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,7 +16,7 @@
         {
           "type": "toml",
           "path": "uv.lock",
-          "jsonpath": "$.package[?(@.name.value=='py-launch-blueprint')].version"
+          "jsonpath": "$.package[?(@.name.value=='py-launch-blueprint' && @.source.editable.value=='.')].version"
         }
       ],
       "changelog-sections": [

--- a/tests/meta/test_version_consistency.py
+++ b/tests/meta/test_version_consistency.py
@@ -20,10 +20,10 @@
 """Guard that the project version stays single-sourced.
 
 ``pyproject.toml`` ``[project] version`` is the single source of truth (ADR-06).
-release-please bumps it together with ``.release-please-manifest.json``, and the
-CLI/docs derive their version from the installed package metadata
-(``py_launch_blueprint.__version__``). These tests fail if any of those copies
-drift apart.
+release-please bumps it together with ``.release-please-manifest.json`` and the
+editable root entry in ``uv.lock``. The CLI/docs derive their version from the
+installed package metadata (``py_launch_blueprint.__version__``). These tests
+fail if any copy or the atomic release updater drifts.
 """
 
 import json
@@ -33,6 +33,11 @@ from pathlib import Path
 from py_launch_blueprint import __version__
 
 ROOT = Path(__file__).resolve().parents[2]
+UV_LOCK_UPDATER = {
+    "type": "toml",
+    "path": "uv.lock",
+    "jsonpath": "$.package[?(@.name.value=='py-launch-blueprint')].version",
+}
 
 
 def _pyproject_version() -> str:
@@ -48,6 +53,26 @@ def _manifest_version() -> str:
 def test_manifest_matches_pyproject():
     """release-please bumps both; they must never diverge."""
     assert _manifest_version() == _pyproject_version()
+
+
+def test_uv_lock_matches_pyproject():
+    """The editable root package metadata must match the source version."""
+    data = tomllib.loads((ROOT / "uv.lock").read_text())
+    editable_packages = [
+        package
+        for package in data["package"]
+        if package["name"] == "py-launch-blueprint"
+        and package.get("source", {}).get("editable") == "."
+    ]
+
+    assert len(editable_packages) == 1
+    assert editable_packages[0]["version"] == _pyproject_version()
+
+
+def test_release_please_updates_uv_lock_atomically():
+    """The release commit must include uv.lock before the PR becomes visible."""
+    config = json.loads((ROOT / "release-please-config.json").read_text())
+    assert UV_LOCK_UPDATER in config["packages"]["."]["extra-files"]
 
 
 def test_installed_version_matches_pyproject():

--- a/tests/meta/test_version_consistency.py
+++ b/tests/meta/test_version_consistency.py
@@ -36,7 +36,8 @@ ROOT = Path(__file__).resolve().parents[2]
 UV_LOCK_UPDATER = {
     "type": "toml",
     "path": "uv.lock",
-    "jsonpath": "$.package[?(@.name.value=='py-launch-blueprint')].version",
+    "jsonpath": "$.package[?(@.name.value=='py-launch-blueprint' && "
+    "@.source.editable.value=='.')].version",
 }
 
 

--- a/tests/meta/test_version_consistency.py
+++ b/tests/meta/test_version_consistency.py
@@ -36,7 +36,7 @@ ROOT = Path(__file__).resolve().parents[2]
 UV_LOCK_UPDATER = {
     "type": "toml",
     "path": "uv.lock",
-    "jsonpath": "$.package[?(@.name.value=='py-launch-blueprint' && "
+    "jsonpath": "$.package[?(@.source && @.source.editable && "
     "@.source.editable.value=='.')].version",
 }
 
@@ -62,8 +62,7 @@ def test_uv_lock_matches_pyproject():
     editable_packages = [
         package
         for package in data["package"]
-        if package["name"] == "py-launch-blueprint"
-        and package.get("source", {}).get("editable") == "."
+        if package.get("source", {}).get("editable") == "."
     ]
 
     assert len(editable_packages) == 1

--- a/tests/meta/test_version_consistency.py
+++ b/tests/meta/test_version_consistency.py
@@ -42,12 +42,14 @@ UV_LOCK_UPDATER = {
 
 
 def _pyproject_version() -> str:
-    data = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    data = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     return data["project"]["version"]
 
 
 def _manifest_version() -> str:
-    data = json.loads((ROOT / ".release-please-manifest.json").read_text())
+    data = json.loads(
+        (ROOT / ".release-please-manifest.json").read_text(encoding="utf-8")
+    )
     return data["."]
 
 
@@ -58,7 +60,7 @@ def test_manifest_matches_pyproject():
 
 def test_uv_lock_matches_pyproject():
     """The editable root package metadata must match the source version."""
-    data = tomllib.loads((ROOT / "uv.lock").read_text())
+    data = tomllib.loads((ROOT / "uv.lock").read_text(encoding="utf-8"))
     editable_packages = [
         package
         for package in data["package"]
@@ -71,7 +73,9 @@ def test_uv_lock_matches_pyproject():
 
 def test_release_please_updates_uv_lock_atomically():
     """The release commit must include uv.lock before the PR becomes visible."""
-    config = json.loads((ROOT / "release-please-config.json").read_text())
+    config = json.loads(
+        (ROOT / "release-please-config.json").read_text(encoding="utf-8")
+    )
     assert UV_LOCK_UPDATER in config["packages"]["."]["extra-files"]
 
 


### PR DESCRIPTION
## Summary

- make release-please update the editable project entry in `uv.lock` in the same generated commit as `pyproject.toml`
- remove the follow-up lockfile repair job and its inconsistent intermediate PR revision
- add regression coverage for lockfile parity, release configuration, and template rebranding
- document the atomic release invariant

## Root cause

The release version was coupled across `pyproject.toml` and the editable root package metadata in `uv.lock`, but release-please owned only the former. A second workflow repaired the lockfile after PR creation, leaving the first release-PR revision stale and able to fail `uv lock --check`.

## Validation

- `UV_CACHE_DIR=$PWD/.uv-cache just check` (266 passed)
- `UV_CACHE_DIR=$PWD/.uv-cache uv lock --check`
- manifest drift check
- init test suite (82 passed)
- commit and pre-push Lefthook suites

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/smorinlabs/codesmith/py-launch-blueprint/pr/500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787288679&installation_model_id=425421&pr_number=500&repository=smorinlabs%2Fpy-launch-blueprint&return_to=https%3A%2F%2Fgithub.com%2Fsmorinlabs%2Fpy-launch-blueprint%2Fpull%2F500&signature=791bfd9d3623039eba796ba905ed1feeab88e10bd303c76b4cc9238e17bdb8ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->