### PR TITLE
ci(security): gate public-only workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,8 @@
 # CodeQL config. The repo's "default setup" (Settings > Code security) must
 # stay disabled, or the SARIF upload is rejected with a configuration error.
 # See SECURITY.md > Code Scanning Setup. This applies to every fork too.
+# GitHub Code Security is unavailable to unlicensed private repositories, so
+# the job stays skipped until the repository becomes public.
 
 name: CodeQL
 
@@ -16,6 +18,7 @@ on:
     branches: [main]
   schedule:
     - cron: '0 4 * * 0'  # weekly, Sunday 04:00 UTC
+  public:
 
 permissions: {}
 
@@ -25,6 +28,7 @@ concurrency:
 
 jobs:
   analyze:
+    if: ${{ github.event.repository.private == false }}
     name: analyze (python)
     runs-on: ${{ vars.RUNNER_UBUNTU || 'ubuntu-latest' }}
     permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,16 +33,16 @@ jobs:
     permissions:
       contents: read
     outputs:
-      is-public: ${{ steps.visibility.outputs.is-public }}
+      is-public: ${{ steps.visibility.outputs.result }}
     steps:
       - name: Inspect repository visibility
         id: visibility
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPOSITORY: ${{ github.repository }}
-        run: |
-          is_public="$(gh api "repos/${REPOSITORY}" --jq '.visibility == "public"')"
-          echo "is-public=${is_public}" >> "${GITHUB_OUTPUT}"
+        uses: actions/github-script@v9
+        with:
+          result-encoding: string
+          script: |
+            const { data: repository } = await github.rest.repos.get(context.repo);
+            return repository.visibility === "public";
 
   analyze:
     needs: repository-visibility

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,8 +27,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  repository-visibility:
+    name: inspect repository visibility
+    runs-on: ${{ vars.RUNNER_UBUNTU || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+    outputs:
+      is-public: ${{ steps.visibility.outputs.is-public }}
+    steps:
+      - name: Inspect repository visibility
+        id: visibility
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          is_public="$(gh api "repos/${REPOSITORY}" --jq '.visibility == "public"')"
+          echo "is-public=${is_public}" >> "${GITHUB_OUTPUT}"
+
   analyze:
-    if: ${{ github.event.repository.private == false }}
+    needs: repository-visibility
+    if: ${{ needs.repository-visibility.outputs.is-public == 'true' }}
     name: analyze (python)
     runs-on: ${{ vars.RUNNER_UBUNTU || 'ubuntu-latest' }}
     permissions:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -26,6 +26,8 @@
 #
 # Source repository: https://github.com/actions/dependency-review-action
 # Public documentation: GitHub Dependency Review enforcement docs.
+# Dependency Review requires GitHub Code Security in private repositories; the
+# job activates automatically on the next PR after the repository becomes public.
 name: 'Dependency review'
 on:
   pull_request:
@@ -44,6 +46,7 @@ permissions:
 
 jobs:
   dependency-review:
+    if: ${{ github.event.repository.private == false }}
     runs-on: ${{ vars.RUNNER_UBUNTU || 'ubuntu-latest' }}
     steps:
       - name: 'Checkout repository'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -46,7 +46,7 @@ permissions:
 
 jobs:
   dependency-review:
-    if: ${{ github.event.repository.private == false }}
+    if: ${{ github.event.repository.visibility == 'public' }}
     runs-on: ${{ vars.RUNNER_UBUNTU || 'ubuntu-latest' }}
     steps:
       - name: 'Checkout repository'

--- a/tests/meta/test_security_workflow_visibility.py
+++ b/tests/meta/test_security_workflow_visibility.py
@@ -12,8 +12,8 @@ PUBLIC_REPOSITORY_CONDITION = "${{ github.event.repository.private == false }}"
 def _job_block(workflow: str, job_name: str) -> str:
     """Return one top-level job block from a workflow's raw YAML."""
     marker = f"  {job_name}:\n"
-    start = workflow.index(marker)
-    remainder = workflow[start + len(marker) :]
+    _, separator, remainder = workflow.partition(marker)
+    assert separator, f"workflow job {job_name!r} was not found"
     next_job_offsets = [
         offset
         for offset, line in enumerate(remainder.splitlines(keepends=True))
@@ -42,8 +42,9 @@ def test_security_workflow_jobs_skip_private_repositories(
 def test_codeql_runs_when_repository_becomes_public() -> None:
     """The visibility change must trigger the first public CodeQL scan."""
     workflow = (WORKFLOW_DIR / "codeql.yml").read_text(encoding="utf-8")
-    triggers = workflow.split("\non:\n", maxsplit=1)[1].split(
-        "\npermissions:", maxsplit=1
-    )[0]
+    _, on_separator, after_on = workflow.partition("\non:\n")
+    assert on_separator, "codeql.yml has no top-level on block"
+    triggers, permissions_separator, _ = after_on.partition("\npermissions:")
+    assert permissions_separator, "codeql.yml has no top-level permissions block"
 
     assert "\n  public:\n" in triggers

--- a/tests/meta/test_security_workflow_visibility.py
+++ b/tests/meta/test_security_workflow_visibility.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_DIR = ROOT / ".github" / "workflows"
-PULL_REQUEST_PUBLIC_CONDITION = "${{ github.event.repository.private == false }}"
+PULL_REQUEST_PUBLIC_CONDITION = "${{ github.event.repository.visibility == 'public' }}"
 CODEQL_PUBLIC_CONDITION = (
     "${{ needs.repository-visibility.outputs.is-public == 'true' }}"
 )

--- a/tests/meta/test_security_workflow_visibility.py
+++ b/tests/meta/test_security_workflow_visibility.py
@@ -42,7 +42,8 @@ def test_codeql_uses_trigger_independent_repository_visibility() -> None:
     visibility_job = _job_block(workflow, "repository-visibility")
     analyze_job = _job_block(workflow, "analyze")
 
-    assert 'gh api "repos/${REPOSITORY}"' in visibility_job
+    assert "uses: actions/github-script@v9" in visibility_job
+    assert 'repository.visibility === "public"' in visibility_job
     assert "    needs: repository-visibility\n" in analyze_job
     assert f"    if: {CODEQL_PUBLIC_CONDITION}\n" in analyze_job
 

--- a/tests/meta/test_security_workflow_visibility.py
+++ b/tests/meta/test_security_workflow_visibility.py
@@ -2,11 +2,12 @@
 
 from pathlib import Path
 
-import pytest
-
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_DIR = ROOT / ".github" / "workflows"
-PUBLIC_REPOSITORY_CONDITION = "${{ github.event.repository.private == false }}"
+PULL_REQUEST_PUBLIC_CONDITION = "${{ github.event.repository.private == false }}"
+CODEQL_PUBLIC_CONDITION = (
+    "${{ needs.repository-visibility.outputs.is-public == 'true' }}"
+)
 
 
 def _job_block(workflow: str, job_name: str) -> str:
@@ -26,17 +27,24 @@ def _job_block(workflow: str, job_name: str) -> str:
     return "".join(lines[: next_job_offsets[0]])
 
 
-@pytest.mark.parametrize(
-    ("workflow_name", "job_name"),
-    [("codeql.yml", "analyze"), ("dependency-review.yml", "dependency-review")],
-)
-def test_security_workflow_jobs_skip_private_repositories(
-    workflow_name: str, job_name: str
-) -> None:
-    """Unavailable GitHub security products must not fail private repos."""
-    workflow = (WORKFLOW_DIR / workflow_name).read_text(encoding="utf-8")
+def test_dependency_review_skips_private_repositories() -> None:
+    """Dependency Review must not fail private pull requests."""
+    workflow = (WORKFLOW_DIR / "dependency-review.yml").read_text(encoding="utf-8")
 
-    assert f"    if: {PUBLIC_REPOSITORY_CONDITION}\n" in _job_block(workflow, job_name)
+    assert f"    if: {PULL_REQUEST_PUBLIC_CONDITION}\n" in _job_block(
+        workflow, "dependency-review"
+    )
+
+
+def test_codeql_uses_trigger_independent_repository_visibility() -> None:
+    """CodeQL must gate every trigger, including schedule, on API visibility."""
+    workflow = (WORKFLOW_DIR / "codeql.yml").read_text(encoding="utf-8")
+    visibility_job = _job_block(workflow, "repository-visibility")
+    analyze_job = _job_block(workflow, "analyze")
+
+    assert 'gh api "repos/${REPOSITORY}"' in visibility_job
+    assert "    needs: repository-visibility\n" in analyze_job
+    assert f"    if: {CODEQL_PUBLIC_CONDITION}\n" in analyze_job
 
 
 def test_codeql_runs_when_repository_becomes_public() -> None:

--- a/tests/meta/test_security_workflow_visibility.py
+++ b/tests/meta/test_security_workflow_visibility.py
@@ -1,0 +1,49 @@
+"""Guard visibility-aware GitHub security workflows."""
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = ROOT / ".github" / "workflows"
+PUBLIC_REPOSITORY_CONDITION = "${{ github.event.repository.private == false }}"
+
+
+def _job_block(workflow: str, job_name: str) -> str:
+    """Return one top-level job block from a workflow's raw YAML."""
+    marker = f"  {job_name}:\n"
+    start = workflow.index(marker)
+    remainder = workflow[start + len(marker) :]
+    next_job_offsets = [
+        offset
+        for offset, line in enumerate(remainder.splitlines(keepends=True))
+        if line.startswith("  ") and not line.startswith("    ")
+    ]
+    if not next_job_offsets:
+        return remainder
+
+    lines = remainder.splitlines(keepends=True)
+    return "".join(lines[: next_job_offsets[0]])
+
+
+@pytest.mark.parametrize(
+    ("workflow_name", "job_name"),
+    [("codeql.yml", "analyze"), ("dependency-review.yml", "dependency-review")],
+)
+def test_security_workflow_jobs_skip_private_repositories(
+    workflow_name: str, job_name: str
+) -> None:
+    """Unavailable GitHub security products must not fail private repos."""
+    workflow = (WORKFLOW_DIR / workflow_name).read_text(encoding="utf-8")
+
+    assert f"    if: {PUBLIC_REPOSITORY_CONDITION}\n" in _job_block(workflow, job_name)
+
+
+def test_codeql_runs_when_repository_becomes_public() -> None:
+    """The visibility change must trigger the first public CodeQL scan."""
+    workflow = (WORKFLOW_DIR / "codeql.yml").read_text(encoding="utf-8")
+    triggers = workflow.split("\non:\n", maxsplit=1)[1].split(
+        "\npermissions:", maxsplit=1
+    )[0]
+
+    assert "\n  public:\n" in triggers


### PR DESCRIPTION
## Summary

- skip CodeQL and Dependency Review jobs while the repository is private
- trigger CodeQL immediately when the repository becomes public
- add regression tests that lock in both visibility guards

## Root cause

GitHub Code Security features are unavailable to private repositories without
the required licensing. The template enabled those jobs unconditionally, so a
new private repository inherited workflows that could only fail. A job-level
repository-visibility guard keeps the workflows present but inactive until the
repository is public.

## Validation

- `UV_CACHE_DIR=$PWD/.uv-cache just check` (269 passed, 4 deselected)
- `UV_CACHE_DIR=$PWD/.uv-cache uv run pytest init/tests/ --override-ini=addopts= -q` (82 passed)
- `uv lock --check`
- `actionlint .github/workflows/*.yml`
- pre-commit and pre-push hooks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/smorinlabs/codesmith/py-launch-blueprint/pr/503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787329712&installation_model_id=425421&pr_number=503&repository=smorinlabs%2Fpy-launch-blueprint&return_to=https%3A%2F%2Fgithub.com%2Fsmorinlabs%2Fpy-launch-blueprint%2Fpull%2F503&signature=2758e199b29fdf5a75ac318bf170660bf92b784131f497346965471c4d10c05d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated security workflows to avoid running on private repositories when required licensing isn’t available.
  * Added a visibility check so CodeQL analysis runs only once the repository becomes public.
  * Clarified workflow activation and behavior in workflow documentation.

* **Tests**
  * Added automated coverage to ensure security workflows correctly skip or activate based on repository visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->