### PR TITLE
fix(guard): accept a press receipt as an initialized marker

### DIFF
--- a/init/ci/check_no_marker.sh
+++ b/init/ci/check_no_marker.sh
@@ -9,13 +9,19 @@
 #
 # Layered defense: `init --prune` also deletes the workflow file itself.
 #
-# Exit 0  → all good (marker absent, or repo is not the blueprint)
-# Exit 1  → marker present in the blueprint repo
+# The press receipt (press/press-receipt.toml) is the same foot-gun via the
+# external engine: guard.sh accepts it as an initialized marker, so a receipt
+# committed to the blueprint would silently disarm both guard tiers in every
+# generated project. It is rejected here alongside the legacy marker.
+#
+# Exit 0  → all good (marker and receipt absent, or repo is not the blueprint)
+# Exit 1  → marker or receipt present in the blueprint repo
 
 set -eu
 
 scope="${GITHUB_REPOSITORY:-}"
 marker_path="${MARKER_PATH:-init/.blueprint-initialized}"
+receipt_path="${RECEIPT_PATH:-press/press-receipt.toml}"
 
 # Outside the blueprint repo this check is a no-op.
 case "$scope" in
@@ -35,5 +41,11 @@ if [ -f "$marker_path" ]; then
     exit 1
 fi
 
-printf 'check_no_marker: %s absent — ok\n' "$marker_path"
+if [ -f "$receipt_path" ]; then
+    printf >&2 'check_no_marker: %s exists in the blueprint repo — '\
+'someone has run `press rebrand` here and committed the receipt. Revert.\n' "$receipt_path"
+    exit 1
+fi
+
+printf 'check_no_marker: %s and %s absent — ok\n' "$marker_path" "$receipt_path"
 exit 0

--- a/init/guard.sh
+++ b/init/guard.sh
@@ -5,8 +5,15 @@
 #
 # Shared skip conditions (any one of them silences both modes):
 #   1. init/.blueprint-initialized exists  → migration already done
-#   2. init/.blueprint-contributor exists  → local opt-out for blueprint maintainers
-#   3. origin URL (normalized) matches the canonical blueprint repo
+#   2. press/press-receipt.toml exists     → rebranded by template-press
+#   3. init/.blueprint-contributor exists  → local opt-out for blueprint maintainers
+#   4. origin URL (normalized) matches the canonical blueprint repo
+#
+# Condition 2 exists because the rebrand engine is migrating out of this repo:
+# `press rebrand` writes a receipt where init.py writes the marker, and a fork
+# pressed with the external tool must not be blocked forever by a guard that
+# only recognizes the embedded engine's artifact. Both are accepted — this is
+# additive, so forks carrying only the legacy marker keep working untouched.
 #
 # POSIX-y bash; no Python, no venv. Hot path: runs before `uv sync` on a bare clone.
 
@@ -14,6 +21,7 @@ set -u
 
 guard_dir="$(cd "$(dirname "$0")" && pwd)"
 marker="${guard_dir}/.blueprint-initialized"
+receipt="${guard_dir}/../press/press-receipt.toml"
 contributor="${guard_dir}/.blueprint-contributor"
 
 # Canonical blueprint owner/repo pairs. Pre-org-move (`smorin/`) included so
@@ -40,6 +48,7 @@ origin_matches_blueprint() {
 
 should_skip() {
     [ -f "$marker" ] && return 0
+    [ -f "$receipt" ] && return 0
     [ -f "$contributor" ] && return 0
     origin_matches_blueprint && return 0
     return 1

--- a/init/init-spec.md
+++ b/init/init-spec.md
@@ -88,7 +88,7 @@ Inventory of `github.com/smorinlabs/py-launch-blueprint` (fetched and verified):
 | **`init-doctor`** | **Report by default**; `--fix` handles only the safe **environment** class (installs). Migration/identity drift is reported but only ever *changed* by `init`. |
 | **Implementation** | `init.py` / `init_doctor.py` are **Python PEP 723 inline-metadata scripts** run via `uv run` — `uv` provisions an ephemeral env, so they need no project venv. `tomlkit` preserves comments on structured edits. (Guard implementation: see the Tier rows above.) |
 | **Exposure** | `just` recipes only — never subcommands of the project's own CLI (bootstrap + ownership reasons). |
-| **Containment** | Everything lives in `init/`, including the markers. The only footprint outside `init/` is in the `Justfile` (the Tier-1 `_blueprint_notice` variable, the `_guard` recipe, the `_guard` dependency token on each subset recipe, and the `init` / `init-doctor` recipes), one CI workflow, and one `.gitignore` line — all removed by `init --prune`. Default is **keep** (the guard self-silences post-init, and `init-doctor`'s environment checks stay useful). |
+| **Containment** | Everything lives in `init/`, including the markers. The only footprint outside `init/` is in the `Justfile` (the Tier-1 `_blueprint_notice` variable, the `_guard` recipe, the `_guard` dependency token on each subset recipe, and the `init` / `init-doctor` recipes), one CI workflow, and one `.gitignore` line — all removed by `init --prune`. The press receipt (`press/press-receipt.toml`) is the one external artifact the guard *reads* but does not own: it is written by the external template-press engine, and `init --prune` neither creates nor removes it. Default is **keep** (the guard self-silences post-init, and `init-doctor`'s environment checks stay useful). |
 
 ---
 
@@ -132,7 +132,9 @@ POSIX shell — no Python, no venv. Both tiers share four **skip conditions**: t
 `init/.blueprint-initialized` exists, the press receipt `press/press-receipt.toml` exists
 (the repo was rebranded by the external template-press engine), the contribution sentinel
 `init/.blueprint-contributor` exists, or `git remote get-url origin` (normalized for
-SSH/HTTPS/`.git`) matches the original `smorinlabs/py-launch-blueprint`.
+SSH/HTTPS/`.git`) matches the original `smorinlabs/py-launch-blueprint` (or its
+pre-org-move alias `smorin/py-launch-blueprint`, kept so clones from before the
+org move still get a silent guard).
 
 **Tier 1 — universal discovery warning.** A single parse-time variable near the top of
 the `Justfile`:

--- a/init/init-spec.md
+++ b/init/init-spec.md
@@ -75,12 +75,12 @@ Inventory of `github.com/smorinlabs/py-launch-blueprint` (fetched and verified):
 
 | # | Decision |
 |---|---|
-| **Detection** | A marker file `init/.blueprint-initialized` gates the guard. The guard **skips** (does not block) if any of: the marker exists; `origin` points at the original blueprint repo; or a local contribution sentinel `init/.blueprint-contributor` exists. |
+| **Detection** | A marker file `init/.blueprint-initialized` gates the guard. The guard **skips** (does not block) if any of: the marker exists; a press receipt `press/press-receipt.toml` exists (the repo was rebranded by the external template-press engine); `origin` points at the original blueprint repo; or a local contribution sentinel `init/.blueprint-contributor` exists. |
 | **Contribution sentinel** | `init/.blueprint-contributor` is **git-ignored** — local-only, so it never leaks into a contributor's PR or downstream. It unblocks people who forked the blueprint to contribute back. |
 | **Guard — two tiers** | The guard does two distinct jobs, split: **discovery** (broad, gentle) and **safety** (narrow, hard). |
 | **Tier 1 — discovery** | A non-fatal warning banner printed on **every recipe run**, via a single parse-time `shell()` variable in the `Justfile`. Zero per-recipe boilerplate; covers all current and future recipes automatically. |
 | **Tier 2 — safety** | A **hard block** (`_guard` recipe as a dependency) on only the small risk-based subset — recipes that produce a wrong artifact, an external side effect, or an identity-bearing write (`build`, `pr-to-testrepo`, `clean-pr-to-testrepo`, future `publish`). `init` / `init-doctor` omit it so the escape hatch always works. |
-| **Implementation (guard)** | `init/guard.sh` is **pure shell** (fast, dependency-free), called as `guard.sh warn` (Tier 1) or `guard.sh block` (Tier 2). Both modes share three skip conditions: marker exists, contribution sentinel exists, or `origin` matches the original blueprint repo. The warn mode **must always `exit 0`** — a non-zero exit from a `shell()` call aborts `just`. |
+| **Implementation (guard)** | `init/guard.sh` is **pure shell** (fast, dependency-free), called as `guard.sh warn` (Tier 1) or `guard.sh block` (Tier 2). Both modes share four skip conditions: marker exists, press receipt (`press/press-receipt.toml`) exists, contribution sentinel exists, or `origin` matches the original blueprint repo. The warn mode **must always `exit 0`** — a non-zero exit from a `shell()` call aborts `just`. |
 | **Substitution** | **Manifest-driven structured rewrite.** `init/manifest.toml` is the single source of truth — shared by `init` and `init-doctor`. |
 | **`init` run model** | **Interactive walkthrough** (`questionary`) by default; **`--config answers.toml`** for non-interactive/CI. Every interactive run **persists the answers** it used. |
 | **Idempotency** | **Strict one-shot** — refuses if the marker exists (`--force` overrides). |
@@ -128,10 +128,11 @@ recipes, and the `_guard` dependency token on each Tier-2 subset recipe;
 The guard does two distinct jobs — *discovery* (nudge a developer to run `just init`) and
 *safety* (stop an operation that produces a wrong result un-migrated). These are split
 into two tiers backed by one shell script, `init/guard.sh`, which uses only `git` and
-POSIX shell — no Python, no venv. Both tiers share three **skip conditions**: the marker
-`init/.blueprint-initialized` exists, the contribution sentinel `init/.blueprint-contributor`
-exists, or `git remote get-url origin` (normalized for SSH/HTTPS/`.git`) matches the
-original `smorinlabs/py-launch-blueprint`.
+POSIX shell — no Python, no venv. Both tiers share four **skip conditions**: the marker
+`init/.blueprint-initialized` exists, the press receipt `press/press-receipt.toml` exists
+(the repo was rebranded by the external template-press engine), the contribution sentinel
+`init/.blueprint-contributor` exists, or `git remote get-url origin` (normalized for
+SSH/HTTPS/`.git`) matches the original `smorinlabs/py-launch-blueprint`.
 
 **Tier 1 — universal discovery warning.** A single parse-time variable near the top of
 the `Justfile`:

--- a/init/tests/test_modes.py
+++ b/init/tests/test_modes.py
@@ -198,3 +198,49 @@ class TestMarkerSilences:
         assert warn.returncode == 0
         assert BANNER not in warn.stderr
         assert block.returncode == 0  # block exits 0 when skipping
+
+
+# ──────────────────────────────────────────────────────────────
+# Cross-mode invariant — a press receipt silences everything too
+# ──────────────────────────────────────────────────────────────
+
+
+class TestPressReceiptSilences:
+    """A fork rebranded by template-press carries press/press-receipt.toml
+    instead of init/.blueprint-initialized. The guard accepts either: the
+    rebrand engine is migrating out of this repo, and a pressed fork must
+    not be blocked forever by a guard that only knows the embedded engine's
+    artifact. Additive — the legacy marker keeps working (TestMarkerSilences)."""
+
+    @pytest.fixture(params=["template_button", "gh_template", "clone_reinit", "fork"])
+    def proj(self, tmp_path, request):
+        return build_fixture(tmp_path, request.param)
+
+    def test_receipt_silences_warn_and_block(self, proj):
+        press_dir = proj / "press"
+        press_dir.mkdir(exist_ok=True)
+        (press_dir / "press-receipt.toml").write_text(
+            '[press]\nversion = "3.3.0"\n',
+            encoding="utf-8",
+        )
+        warn = run_guard(proj, "warn")
+        block = run_guard(proj, "block")
+        assert warn.returncode == 0
+        assert BANNER not in warn.stderr, (
+            "a press-rebranded fork must not see the un-initialized banner"
+        )
+        assert block.returncode == 0, "block must exit 0 when a press receipt exists"
+
+    def test_unrelated_press_dir_does_not_silence(self, proj):
+        """Only the receipt counts — a press/ dir without one is ordinary
+        content and must leave the guard firing."""
+        press_dir = proj / "press"
+        press_dir.mkdir(exist_ok=True)
+        (press_dir / "press-source.toml").write_text(
+            '[identity]\napp_name = "plbp"\n',
+            encoding="utf-8",
+        )
+        warn = run_guard(proj, "warn")
+        block = run_guard(proj, "block")
+        assert BANNER in warn.stderr, "a press/ dir without a receipt must not skip"
+        assert block.returncode == 1


### PR DESCRIPTION
Teaches `init/guard.sh` a fourth skip condition: `press/press-receipt.toml` counts as initialized alongside `init/.blueprint-initialized`.

**Why now.** The rebrand engine is migrating to template-press (v3.3.0 shipped the C/D/E conformance-gap closure). A fork rebranded with `press rebrand` gets a receipt, not the legacy marker — so today it satisfies no skip condition and is blocked from `build` / `publish` / `pr-to-testrepo` permanently, with a banner telling it to run an init that already ran. This is a prerequisite for deleting the embedded engine: the guard must not outlive the marker's only writer.

**Additive, not a migration.** Both artifacts are accepted, so forks carrying only the legacy marker are untouched. Only the receipt counts — a `press/` directory without one is ordinary content and still fires the guard (pinned by `test_unrelated_press_dir_does_not_silence`), so an unrelated `press/` dir cannot trip it.

**Tests.** Two new cases in `init/tests/test_modes.py`, parameterized across all four fixture modes. Verified discriminating: with the `guard.sh` change reverted, 4 of them fail. Full `init/tests/` suite: 90 passed. CI guard checks green — `check_no_marker.sh`, `check_guard_wiring.py`, `check_manifest_drift.py`.

Scope: this is the first and smallest step of the `init/` cleanup sequence; no engine code is deleted here.

https://claude.ai/code/session_01SBouRtJrM2cQZd4Mtcgnbi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/smorinlabs/codesmith/py-launch-blueprint/pr/505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787610035&installation_model_id=425421&pr_number=505&repository=smorinlabs%2Fpy-launch-blueprint&return_to=https%3A%2F%2Fgithub.com%2Fsmorinlabs%2Fpy-launch-blueprint%2Fpull%2F505&signature=d2ebc31e08ad8ee4fff34afd5c7e742e839867bfa745a63fe54c06960a4ad9fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * Guard checks now skip warning and blocking behavior when `press/press-receipt.toml` is present.
  * A `press/` directory without the receipt does not suppress guard notifications or blocking.
  * Blueprint validation now detects and reports an unexpected press receipt.

* **Tests**
  * Added coverage confirming receipt-based guard behavior across supported initialization modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->