### PR TITLE
fix(press): receipt-aware pre-push gates, post-press normalization docs, run 4 evidence

### DIFF
--- a/docs/POST_INIT.md
+++ b/docs/POST_INIT.md
@@ -334,14 +334,19 @@ normalize them once, right after the press (run 4 PROBLEM-24/-27):
 
 ```bash
 uv run pytest tests/cli/test_help_snapshots.py --snapshot-update --override-ini=addopts=
-just format
-git add -A && git commit -m "chore: normalize length-sensitive artifacts post-press"
+uv run ruff format .
+git add tests/cli/__snapshots__/test_help_snapshots.ambr
+git add -u
+git commit -m "chore: normalize length-sensitive artifacts post-press"
 ```
 
 - The CLI help snapshots re-wrap at the new name's length (a shorter or
   longer app name moves the 80-column wrap points).
-- `ruff format` re-wraps any rewritten lines the longer identity pushed past
-  the 88-character limit.
+- `uv run ruff format .` (the FULL tree — `just format` covers only the
+  package dir) re-wraps any rewritten lines the new identity pushed past the
+  88-character limit; run 4 saw this in `tests/` and `init/tests/`.
+- `git add -u` stages only tracked modifications (plus the snapshot file
+  explicitly), so unrelated untracked files are never swept into the commit.
 
 A declared `[[regenerate]]` for the snapshots is the intended automation, but
 `press verify`'s exemption cap currently covers only `uv.lock`/`bun.lock`

--- a/docs/POST_INIT.md
+++ b/docs/POST_INIT.md
@@ -330,11 +330,15 @@ you need (`gh secret set NAME -R <owner>/<repo>` prompts for the value).
 ## After a `press rebrand` (external template-press)
 
 Two artifacts are length-sensitive and cannot be fixed by text rewriting —
-normalize them once, right after the press (run 4 PROBLEM-24/-27):
+normalize them once, right after the press (run 4 PROBLEM-24/-27).
+**Precondition: the pressed tree is already committed** (e.g.
+`git add -A && git commit -m "chore: press to <new> identity"`), so the only
+modifications left are the normalization itself:
 
 ```bash
 uv run pytest tests/cli/test_help_snapshots.py --snapshot-update --override-ini=addopts=
 uv run ruff format .
+just check
 git add tests/cli/__snapshots__/test_help_snapshots.ambr
 git add -u
 git commit -m "chore: normalize length-sensitive artifacts post-press"
@@ -345,8 +349,11 @@ git commit -m "chore: normalize length-sensitive artifacts post-press"
 - `uv run ruff format .` (the FULL tree — `just format` covers only the
   package dir) re-wraps any rewritten lines the new identity pushed past the
   88-character limit; run 4 saw this in `tests/` and `init/tests/`.
-- `git add -u` stages only tracked modifications (plus the snapshot file
-  explicitly), so unrelated untracked files are never swept into the commit.
+- `just check` proves the normalization landed (run 4: the snapshot suite
+  went 2 failed → all pass) before anything is committed.
+- With the press committed first, `git add -u` stages exactly the
+  normalization deltas (formatter output is not a fixed file list), and the
+  explicit snapshot path covers the one file syrupy may rewrite in place.
 
 A declared `[[regenerate]]` for the snapshots is the intended automation, but
 `press verify`'s exemption cap currently covers only `uv.lock`/`bun.lock`

--- a/docs/POST_INIT.md
+++ b/docs/POST_INIT.md
@@ -326,3 +326,23 @@ you need (`gh secret set NAME -R <owner>/<repo>` prompts for the value).
 6. Set branch protection + Actions PR permissions (§2.4).
 7. Decide CLA, contributors automation, funding (§1).
 8. Local: run the `scripts/install-*` + `uv sync` steps (§2.5).
+
+## After a `press rebrand` (external template-press)
+
+Two artifacts are length-sensitive and cannot be fixed by text rewriting —
+normalize them once, right after the press (run 4 PROBLEM-24/-27):
+
+```bash
+uv run pytest tests/cli/test_help_snapshots.py --snapshot-update --override-ini=addopts=
+just format
+git add -A && git commit -m "chore: normalize length-sensitive artifacts post-press"
+```
+
+- The CLI help snapshots re-wrap at the new name's length (a shorter or
+  longer app name moves the 80-column wrap points).
+- `ruff format` re-wraps any rewritten lines the longer identity pushed past
+  the 88-character limit.
+
+A declared `[[regenerate]]` for the snapshots is the intended automation, but
+`press verify`'s exemption cap currently covers only `uv.lock`/`bun.lock`
+(template-press PROBLEM-28) — until that widens, this manual step stands.

--- a/docs/research/0004-template-press-dogfood-log.md
+++ b/docs/research/0004-template-press-dogfood-log.md
@@ -370,3 +370,32 @@ no known-gap bucket remains. Numbering continues at PROBLEM-21.
 | 2026-08-17T04:51:12Z | T08 (scope gate) | user decision at gate | DECIDED: full conform (init/ deletion + CI cutover) deferred to a follow-up plan AFTER publish proof (Tasks 10–13); PR #505 authorized to merge now. Run-3 pause condition discharged (green via declarations). |
 | 2026-08-17T04:58:43Z | T10.1 (init integrity) | added press/spec/plan/P05 files to init/manifest.toml ([[replace]] text blocks + 2 [[remove]] entries); check_manifest_drift + init tests | PASS: drift ok; 82 passed; press verify re-run exit 0 after manifest edits |
 | 2026-08-17T04:58:43Z | T10.2 (full gate) | make check && just check | PASS (pre-existing non-fatal yamllint line-length warnings only, per Run 1 precedent) |
+| 2026-08-17T05:26:08Z | T09/T06 (pr #505) | 4 review threads triaged (2 codex, 2 coderabbit): all valid, fixed (spec 4th condition, check_no_marker receipt rejection, containment wording, origin alias); merged via merge queue b135492 | PASS |
+| 2026-08-17T05:26:08Z | T10/T07 (pr #518, round-1) | 5 bot threads over 2 waves: ps1 fail-loud fixed; display_name legacy-init gap deferred x2 (tracked in P05); path/nit declined; manifest-sync partially fixed | MERGED 6f99b76 |
+| 2026-08-17T05:26:08Z | T11 (fresh-main gate) | clone main; press verify + check-tools | PASS both exit 0 (uv.lock/bun.lock exemptions listed by design) |
+| 2026-08-17T05:26:08Z | TS03.1 (dry-run) | press rebrand --dry-run → plan | PASS exit 0: G5 renames, pkg dir rename, regens w/ resolved executables, CHANGELOG 328→stub |
+| 2026-08-17T05:26:08Z | TS03.2 (apply) | press rebrand apply → blueprint-press-dryrun | PASS exit 0: receipt written, source refreshed, 5 binary/symlink review-skips. Independent grep audit CLEAN (content+paths); CHANGELOG stub; bun.lock/uv.lock carry new identity |
+| 2026-08-17T05:26:08Z | TS03.3 (re-press guards) | re-press same identity; wrong-origin source | PASS both refuse exit 2 correctly (receipt guard; discovery mismatch guard — origin must be re-pointed first, plan-order note) |
+| 2026-08-17T05:26:08Z | TS03.4 (forced re-press to 2nd identity) | press --force on copy → press-dryrun-two | FAIL exit 1 → PROBLEM-22/23 below. Receipt invalidation itself fired correctly; incomplete-state contract (no receipt, loud recovery) correct |
+
+### New findings
+
+- **PROBLEM-22** — med — template-press: post-regeneration changed-fields scan
+  false-positives on base64 hash material in regenerated lockfiles. Repro:
+  forced re-press blueprint-press-dryrun → press-dryrun-two; bun.lock
+  regenerates CLEAN (zero real identity tokens) but the scan reports
+  `output still carries source app_name 'bpd'` — the case-glued substring
+  matcher hits `Bpd` inside integrity hash `…x/2Xp/Bpdl…`. Structural for
+  short app names in substring mode (3 chars ≈ guaranteed in a large lock);
+  first press succeeded by luck (`plbp` variants absent). Workaround: none
+  target-side (D-v4-5: no ignores for engine gaps). Root cause:
+  `scan_regenerated_output` applies the strictest matcher (case/separator-
+  glued substring) to hash-dense regenerated artifacts. Disposition:
+  template-press fix, design options to user (scan-policy per regen rule vs
+  case-sensitive substring in regen scans vs entropy-aware exclusion).
+- **PROBLEM-23** — low — template-press: the regen-failure path prints only
+  the error banner and summary counts; `report.skipped` (which carries the
+  exact per-file reason, e.g. the PROBLEM-22 scan hit) is printed only on
+  the success path (`cli.py` ~471 vs ~575). Diagnosing PROBLEM-22 required
+  monkeypatching a spy around `execute_regenerations`. Disposition:
+  template-press fix — print skipped entries on the failure path too.

--- a/docs/research/0004-template-press-dogfood-log.md
+++ b/docs/research/0004-template-press-dogfood-log.md
@@ -377,6 +377,11 @@ no known-gap bucket remains. Numbering continues at PROBLEM-21.
 | 2026-08-17T05:26:08Z | TS03.2 (apply) | press rebrand apply → blueprint-press-dryrun | PASS exit 0: receipt written, source refreshed, 5 binary/symlink review-skips. Independent grep audit CLEAN (content+paths); CHANGELOG stub; bun.lock/uv.lock carry new identity |
 | 2026-08-17T05:26:08Z | TS03.3 (re-press guards) | re-press same identity; wrong-origin source | PASS both refuse exit 2 correctly (receipt guard; discovery mismatch guard — origin must be re-pointed first, plan-order note) |
 | 2026-08-17T05:26:08Z | TS03.4 (forced re-press to 2nd identity) | press --force on copy → press-dryrun-two | FAIL exit 1 → PROBLEM-22/23 below. Receipt invalidation itself fired correctly; incomplete-state contract (no receipt, loud recovery) correct |
+| 2026-08-17T05:50:00Z | TS03.4b (forced re-press, retest) | same forced re-press with the PROBLEM-22 fix branch (template-press fix/run4-regen-scan-policy) + `scan = "boundary"` declared on the copy's bun.lock regens | PASS exit 0: prior receipt invalidated, new receipt written, verified. Battery item closes on this evidence; the engine fix is in a template-press PR (merge pending) |
+| 2026-08-17T05:28:18Z | TS03.5 (check-tools) | press check-tools on instance | PASS exit 0 (git, uv, regen script). Negative case n/a by design: check-tools resolves the declared script, not tools inside it — the script fails loud at run time instead |
+| 2026-08-17T05:28:18Z | TS03.6 (instance stands alone) | mise trust && make check && just setup && just check | FAIL first run: 2 syrupy help-snapshot tests (bpd config set/get) — PROBLEM-24. After snapshot refresh: just check PASS exit 0 (267+11 tests; instance hooks wired and firing) |
+| 2026-08-17T05:45:53Z | T13 (publish) | gh repo create smorinlabs/blueprint-press-dryrun (user-authorized); git push | First push BLOCKED by fork's own pre-push init-integrity gates (PROBLEM-25); after receipt-gate hand-fix, push OK. CI wave 1: blueprint-guard + init-integration FAIL (PROBLEM-26), ruff format FAIL (PROBLEM-27), dependency-review FAIL (repo provisioning: dependency graph off — observation, accepted for throwaway). Hand-fixes (logged): just format; delete the two blueprint-only workflows |
+| 2026-08-17T05:48:49Z | T13 (publish, final) | CI on fixed head 5c42cec | GREEN: CI/CD, lint, CodeQL, secret-scan, commitlint, large-file-guard all pass. Only reds: release-please + Update Contributors — both "Provide either app-id + private-key, or pat" (credential-gated app workflows, pre-accepted class per spec §5). Publish exit criterion MET |
 
 ### New findings
 
@@ -399,8 +404,6 @@ no known-gap bucket remains. Numbering continues at PROBLEM-21.
   the success path (`cli.py` ~471 vs ~575). Diagnosing PROBLEM-22 required
   monkeypatching a spy around `execute_regenerations`. Disposition:
   template-press fix — print skipped entries on the failure path too.
-| 2026-08-17T05:28:18Z | TS03.5 (check-tools) | press check-tools on instance | PASS exit 0 (git, uv, regen script). Negative case n/a by design: check-tools resolves the declared script, not tools inside it — the script fails loud at run time instead |
-| 2026-08-17T05:28:18Z | TS03.6 (instance stands alone) | mise trust && make check && just setup && just check | FAIL first run: 2 syrupy help-snapshot tests (bpd config set/get) — PROBLEM-24. After snapshot refresh: just check PASS exit 0 (267+11 tests; instance hooks wired and firing) |
 - **PROBLEM-24** — med — blueprint: CLI help-snapshot tests (WL-023, syrupy
   `.ambr`) fail in a pressed fork whenever the app name changes length —
   the press rewrites snapshot text faithfully, but argparse/click re-wraps
@@ -414,7 +417,6 @@ no known-gap bucket remains. Numbering continues at PROBLEM-21.
   regenerate). Caveat to evaluate: the command needs the fork's uv env
   (first run syncs deps, may need network) inside the press's
   deny-by-default command env.
-| 2026-08-17T05:45:53Z | T13 (publish) | gh repo create smorinlabs/blueprint-press-dryrun (user-authorized); git push | First push BLOCKED by fork's own pre-push init-integrity gates (PROBLEM-25); after receipt-gate hand-fix, push OK. CI wave 1: blueprint-guard + init-integration FAIL (PROBLEM-26), ruff format FAIL (PROBLEM-27), dependency-review FAIL (repo provisioning: dependency graph off — observation, accepted for throwaway). Hand-fixes (logged): just format; delete the two blueprint-only workflows |
 - **PROBLEM-21** — low — blueprint: press control files are not rewritten by
   design, so identity tokens embedded in `press/press-rules.toml` COMMENTS
   ship stale into every pressed fork (the G3 comment named the app token
@@ -451,4 +453,3 @@ no known-gap bucket remains. Numbering continues at PROBLEM-21.
   is already "earned by result" at real-press time) or add a declared
   exemption schema; until then PROBLEM-24 falls back to the documented
   post-press step (docs/POST_INIT.md).
-| 2026-08-17T05:48:49Z | T13 (publish, final) | CI on fixed head 5c42cec | GREEN: CI/CD, lint, CodeQL, secret-scan, commitlint, large-file-guard all pass. Only reds: release-please + Update Contributors — both "Provide either app-id + private-key, or pat" (credential-gated app workflows, pre-accepted class per spec §5). Publish exit criterion MET |

--- a/docs/research/0004-template-press-dogfood-log.md
+++ b/docs/research/0004-template-press-dogfood-log.md
@@ -451,3 +451,4 @@ no known-gap bucket remains. Numbering continues at PROBLEM-21.
   is already "earned by result" at real-press time) or add a declared
   exemption schema; until then PROBLEM-24 falls back to the documented
   post-press step (docs/POST_INIT.md).
+| 2026-08-17T05:48:49Z | T13 (publish, final) | CI on fixed head 5c42cec | GREEN: CI/CD, lint, CodeQL, secret-scan, commitlint, large-file-guard all pass. Only reds: release-please + Update Contributors — both "Provide either app-id + private-key, or pat" (credential-gated app workflows, pre-accepted class per spec §5). Publish exit criterion MET |

--- a/docs/research/0004-template-press-dogfood-log.md
+++ b/docs/research/0004-template-press-dogfood-log.md
@@ -414,3 +414,28 @@ no known-gap bucket remains. Numbering continues at PROBLEM-21.
   regenerate). Caveat to evaluate: the command needs the fork's uv env
   (first run syncs deps, may need network) inside the press's
   deny-by-default command env.
+| 2026-08-17T05:45:53Z | T13 (publish) | gh repo create smorinlabs/blueprint-press-dryrun (user-authorized); git push | First push BLOCKED by fork's own pre-push init-integrity gates (PROBLEM-25); after receipt-gate hand-fix, push OK. CI wave 1: blueprint-guard + init-integration FAIL (PROBLEM-26), ruff format FAIL (PROBLEM-27), dependency-review FAIL (repo provisioning: dependency graph off — observation, accepted for throwaway). Hand-fixes (logged): just format; delete the two blueprint-only workflows |
+- **PROBLEM-21** — low — blueprint: press control files are not rewritten by
+  design, so identity tokens embedded in `press/press-rules.toml` COMMENTS
+  ship stale into every pressed fork (the G3 comment named the app token
+  literally). Disposition: blueprint — reword control-file comments to be
+  identity-free (fixed this round); candidate template-press doc guidance.
+- **PROBLEM-25** — high — blueprint: the four lefthook init-integrity
+  pre-push gates (`guard-wiring`, `manifest-drift`, `path-filter`,
+  `init-tests`) key on `init/.blueprint-initialized` only, so a pressed
+  fork (receipt, no marker) runs — and fails — blueprint-maintenance
+  checks, blocking every push. Same class as Run-1 PROBLEM-11; PR #505's
+  contract covered guard.sh but not lefthook. Disposition: blueprint —
+  accept `press/press-receipt.toml` in all four gates (fixed this round;
+  instance hand-fixed identically to publish).
+- **PROBLEM-26** — med/high — template-press: no file-removal mechanism.
+  Everything the legacy engine deletes via `init/manifest.toml [[remove]]`
+  (blueprint-only CI: `blueprint-guard.yml`, `init-integration.yml`;
+  dogfood history docs) ships to pressed forks; the two workflows FAIL
+  there. Disposition: template-press feature — declared `[[remove]]` in
+  press-rules (G-register class); fork hand-fix applied to the instance.
+- **PROBLEM-27** — low/med — blueprint/template-design: a longer pressed
+  identity pushes rewritten lines past ruff's 88-char limit (2 files) —
+  same class as PROBLEM-24 (length-sensitive artifacts vs text rewrite).
+  Disposition: fork runs `just format` post-press (hand-fixed on the
+  instance); folds into the post-press normalization story with P24.

--- a/docs/research/0004-template-press-dogfood-log.md
+++ b/docs/research/0004-template-press-dogfood-log.md
@@ -439,3 +439,15 @@ no known-gap bucket remains. Numbering continues at PROBLEM-21.
   same class as PROBLEM-24 (length-sensitive artifacts vs text rewrite).
   Disposition: fork runs `just format` post-press (hand-fixed on the
   instance); folds into the post-press normalization story with P24.
+- **PROBLEM-28** — med — template-press: the hermetic-verify regeneration
+  exemption is a hardcoded filename allowlist
+  (`pathing.REGENERATE_EXEMPTIBLE = {"uv.lock", "bun.lock"}`). Any other
+  declared `[[regenerate]]` output — e.g. the help-snapshot `.ambr`
+  (PROBLEM-24) — makes `press verify` structurally exit 1: excluded from
+  rewrite, not exempt from the scan, and the sandbox never runs commands.
+  Empirically the real press handles the same declaration fine (exit 0,
+  post-command scan certifies the output). Disposition: template-press
+  design decision — widen the cap to any declared regeneration (exemption
+  is already "earned by result" at real-press time) or add a declared
+  exemption schema; until then PROBLEM-24 falls back to the documented
+  post-press step (docs/POST_INIT.md).

--- a/docs/research/0004-template-press-dogfood-log.md
+++ b/docs/research/0004-template-press-dogfood-log.md
@@ -439,8 +439,10 @@ no known-gap bucket remains. Numbering continues at PROBLEM-21.
 - **PROBLEM-27** — low/med — blueprint/template-design: a longer pressed
   identity pushes rewritten lines past ruff's 88-char limit (2 files) —
   same class as PROBLEM-24 (length-sensitive artifacts vs text rewrite).
-  Disposition: fork runs `just format` post-press (hand-fixed on the
-  instance); folds into the post-press normalization story with P24.
+  Disposition: fork runs `uv run ruff format .` (full tree — `just
+  format` covers only the package dir) post-press per docs/POST_INIT.md
+  (hand-fixed on the instance); folds into the post-press normalization
+  story with P24.
 - **PROBLEM-28** — med — template-press: the hermetic-verify regeneration
   exemption is a hardcoded filename allowlist
   (`pathing.REGENERATE_EXEMPTIBLE = {"uv.lock", "bun.lock"}`). Any other

--- a/docs/research/0004-template-press-dogfood-log.md
+++ b/docs/research/0004-template-press-dogfood-log.md
@@ -399,3 +399,18 @@ no known-gap bucket remains. Numbering continues at PROBLEM-21.
   the success path (`cli.py` ~471 vs ~575). Diagnosing PROBLEM-22 required
   monkeypatching a spy around `execute_regenerations`. Disposition:
   template-press fix — print skipped entries on the failure path too.
+| 2026-08-17T05:28:18Z | TS03.5 (check-tools) | press check-tools on instance | PASS exit 0 (git, uv, regen script). Negative case n/a by design: check-tools resolves the declared script, not tools inside it — the script fails loud at run time instead |
+| 2026-08-17T05:28:18Z | TS03.6 (instance stands alone) | mise trust && make check && just setup && just check | FAIL first run: 2 syrupy help-snapshot tests (bpd config set/get) — PROBLEM-24. After snapshot refresh: just check PASS exit 0 (267+11 tests; instance hooks wired and firing) |
+- **PROBLEM-24** — med — blueprint: CLI help-snapshot tests (WL-023, syrupy
+  `.ambr`) fail in a pressed fork whenever the app name changes length —
+  the press rewrites snapshot text faithfully, but argparse/click re-wraps
+  usage lines at COLUMNS=80, so the wrap points move (`plbp`→`bpd` shifts
+  `format|` across a line break). No text rewriter can fix generated
+  wrapped text. Proven fix: regenerate, not rewrite — running the
+  documented `uv run pytest tests/cli/test_help_snapshots.py
+  --snapshot-update` in the instance turns 2 failed into 11 passed.
+  Disposition: blueprint — declare the `.ambr` under `[[regenerate]]` in
+  press-rules.toml (press-native: identity-dependent generated artifacts
+  regenerate). Caveat to evaluate: the command needs the fork's uv env
+  (first run syncs deps, may need network) inside the press's
+  deny-by-default command env.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -197,14 +197,17 @@ pre-push:
     init-guard-wiring:
       run: >-
         test -f init/.blueprint-initialized ||
+        test -f press/press-receipt.toml ||
         uv run --script init/ci/check_guard_wiring.py
     init-manifest-drift:
       run: >-
         test -f init/.blueprint-initialized ||
+        test -f press/press-receipt.toml ||
         uv run --script init/ci/check_manifest_drift.py
     init-path-filter:
       run: >-
         test -f init/.blueprint-initialized ||
+        test -f press/press-receipt.toml ||
         uv run --script init/ci/check_path_filter.py
     # Init unit tests (~3s; safe at pre-push, too slow for pre-commit).
     # `--override-ini=addopts=` because the project default excludes
@@ -223,6 +226,7 @@ pre-push:
     init-tests:
       run: >-
         test -f init/.blueprint-initialized ||
+        test -f press/press-receipt.toml ||
         env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE
         -u GIT_OBJECT_DIRECTORY -u GIT_COMMON_DIR -u GIT_PREFIX
         uv run pytest init/tests/ --override-ini="addopts=" -q

--- a/press/press-rules.toml
+++ b/press/press-rules.toml
@@ -3,8 +3,11 @@
 # dogfood Run 3 (G3/G4/G5) are closed by declaration, not by ignores.
 
 [rules]
-# G3: plbp appears in glued forms (_plbp_owned, plbp-web) and PLBP in
-# uppercase glued forms — the token is word-disjoint in this repo.
+# G3: the app short name appears glued (owned-attribute prefix in tests,
+# a "-web" suffix in Dockerfile/Justfile) and in glued UPPERCASE forms —
+# the token is word-disjoint in this repo. Comments here stay free of
+# literal identity tokens: press control files are not rewritten, so a
+# literal would ship stale into every pressed fork (run 4 PROBLEM-21).
 substring_rewrite_fields = ["app_name", "app_name_upper"]
 
 # G2: bun.lock is excluded from rewrite; regenerate under the new identity.

--- a/projects/P05-template-press-v34-dogfood-conform.md
+++ b/projects/P05-template-press-v34-dogfood-conform.md
@@ -18,8 +18,8 @@ generated projects, so this link resolves only in the blueprint itself)
 - [x] [P05-TS01] press check-tools exits 0 against the worktree
 - [x] [P05-TS02] press verify reaches exit 0, zero ignores
 - [x] [P05-T05] Scope gate decision recorded (user)
-- [ ] [P05-T06] PR #505 merged (user-confirmed)
-- [ ] [P05-T07] Round-1 PR merged; verify green from fresh main clone
+- [x] [P05-T06] PR #505 merged (user-confirmed)
+- [x] [P05-T07] Round-1 PR merged; verify green from fresh main clone
 - [x] [P05-TS03] Local rebrand battery passes (dry-run/apply/re-press/check-tools/instance checks)
 - [x] [P05-T08] Instance published to throwaway repo; CI triaged (user-gated)
 - [ ] [P05-T09] Close-out: dispositions, cleanup, report

--- a/projects/P05-template-press-v34-dogfood-conform.md
+++ b/projects/P05-template-press-v34-dogfood-conform.md
@@ -20,8 +20,8 @@ generated projects, so this link resolves only in the blueprint itself)
 - [x] [P05-T05] Scope gate decision recorded (user)
 - [ ] [P05-T06] PR #505 merged (user-confirmed)
 - [ ] [P05-T07] Round-1 PR merged; verify green from fresh main clone
-- [ ] [P05-TS03] Local rebrand battery passes (dry-run/apply/re-press/check-tools/instance checks)
-- [ ] [P05-T08] Instance published to throwaway repo; CI triaged (user-gated)
+- [x] [P05-TS03] Local rebrand battery passes (dry-run/apply/re-press/check-tools/instance checks)
+- [x] [P05-T08] Instance published to throwaway repo; CI triaged (user-gated)
 - [ ] [P05-T09] Close-out: dispositions, cleanup, report
 
 ### Deliverable


### PR DESCRIPTION
Round 2 of the P05 template-press dogfood campaign (spec: docs/superpowers/specs/2026-08-16-template-press-v34-dogfood-design.md).

**Fixes**
- **PROBLEM-25 (high):** the four lefthook init-integrity pre-push gates keyed on the legacy marker only, so a pressed fork (receipt, no marker) ran — and failed — blueprint-maintenance checks, blocking every push (observed live: first push of smorinlabs/blueprint-press-dryrun was blocked). All four now also accept `press/press-receipt.toml`, completing PR #505's contract on the lefthook side.
- **PROBLEM-21 (low):** press control files are not rewritten, so identity tokens in `press-rules.toml` comments shipped stale into forks — comments reworded identity-free.
- **PROBLEM-24/-27:** documented post-press normalization step in docs/POST_INIT.md (snapshot refresh + `just format`) — the declared-[[regenerate]] automation is blocked on template-press#81 (verify exemption cap).

**Evidence**
- Dogfood log Run 4 completed: battery results (TS03), publish results (T08 — instance CI green except the credential-gated app workflows), and PROBLEM-21..28 with dispositions. Engine findings filed: template-press#80 ([[remove]] mechanism), template-press#81 (exemption cap); scan-policy fix (PROBLEM-22/23) in flight in template-press.

https://claude.ai/code/session_016oYMBMYRU8C5yhdCNQcnpi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/smorinlabs/codesmith/py-launch-blueprint/pr/519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789537783&installation_model_id=425421&pr_number=519&repository=smorinlabs%2Fpy-launch-blueprint&return_to=https%3A%2F%2Fgithub.com%2Fsmorinlabs%2Fpy-launch-blueprint%2Fpull%2F519&signature=f35c91f61bd8f8018920a957d525e80583792fe6a1abda0472338f93b5d3481c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for completing post-rebrand cleanup, formatting, snapshot updates, and verification.
  - Recorded validation results, resolved review issues, and publication checks for the latest template run.

- **Bug Fixes**
  - Improved pre-push initialization checks to recognize an existing receipt marker.
  - Clarified identity-matching guidance while preserving existing rewrite behavior.

- **Chores**
  - Marked completed template dogfooding, rebrand verification, and publication tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->