### PR TITLE
docs(projects): close p05 — run 4 dispositions final, exit criteria met

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -26,7 +26,7 @@ file by hand — see Conventions.
 | P02 | `[x]` | [Repo simplification & organization (SIMP series)](projects/P02-repo-simplification.md) — single-purpose PRs to simplify/consolidate Justfile, docs, setup, tests, workflows, agent configs |
 | P03 | `[~]` | [Type Precision Uplevel](projects/P03-type-precision-uplevel.md) — eliminate leaking/overly-general types + verified ty rule promotions + scoped ruff ANN, from a Fable×Codex two-lens audit |
 | P04 | `[x]` | [Py-API Boundary Validation](projects/P04-py-api-boundary-validation.md) — validate Py-API responses at the edge with Pydantic; silent drift → APIError |
-| P05 | `[~]` | [Template-press v3.4 dogfood & conform](projects/P05-template-press-v34-dogfood-conform.md) — press/ config from scratch, verify to declarations-only green, rebrand + publish an instance; findings → Run 4 PROBLEM-NN |
+| P05 | `[x]` | [Template-press v3.4 dogfood & conform](projects/P05-template-press-v34-dogfood-conform.md) — press/ config from scratch, verify to declarations-only green, rebrand + publish an instance; findings → Run 4 PROBLEM-NN |
 
 ## Conventions
 

--- a/docs/research/0004-template-press-dogfood-log.md
+++ b/docs/research/0004-template-press-dogfood-log.md
@@ -382,6 +382,7 @@ no known-gap bucket remains. Numbering continues at PROBLEM-21.
 | 2026-08-17T05:28:18Z | TS03.6 (instance stands alone) | mise trust && make check && just setup && just check | FAIL first run: 2 syrupy help-snapshot tests (bpd config set/get) — PROBLEM-24. After snapshot refresh: just check PASS exit 0 (267+11 tests; instance hooks wired and firing) |
 | 2026-08-17T05:45:53Z | T13 (publish) | gh repo create smorinlabs/blueprint-press-dryrun (user-authorized); git push | First push BLOCKED by fork's own pre-push init-integrity gates (PROBLEM-25); after receipt-gate hand-fix, push OK. CI wave 1: blueprint-guard + init-integration FAIL (PROBLEM-26), ruff format FAIL (PROBLEM-27), dependency-review FAIL (repo provisioning: dependency graph off — observation, accepted for throwaway). Hand-fixes (logged): just format; delete the two blueprint-only workflows |
 | 2026-08-17T05:48:49Z | T13 (publish, final) | CI on fixed head 5c42cec | GREEN: CI/CD, lint, CodeQL, secret-scan, commitlint, large-file-guard all pass. Only reds: release-please + Update Contributors — both "Provide either app-id + private-key, or pat" (credential-gated app workflows, pre-accepted class per spec §5). Publish exit criterion MET |
+| 2026-08-17T07:02:29Z | T14 (close-out) | re-pin press-under-test: template-press main @ 6428a9c (PR #82 merged: scan policy + failure reporting + matrix conformed-blueprint update); fresh-clone final gate: press verify + check-tools vs blueprint main @ 8ed30c3 | PASS both exit 0. Campaign exit criteria met (spec §5). Follow-ups: template-press#80 ([[remove]]), #81 (exemption cap); blueprint adopts scan="boundary" for bun.lock only after the next template-press RELEASE (the key is unknown to v3.4.0 and would break released-press users); full conform (init/ retirement) is the next campaign per the scope gate |
 
 ### New findings
 
@@ -396,8 +397,9 @@ no known-gap bucket remains. Numbering continues at PROBLEM-21.
   target-side (D-v4-5: no ignores for engine gaps). Root cause:
   `scan_regenerated_output` applies the strictest matcher (case/separator-
   glued substring) to hash-dense regenerated artifacts. Disposition:
-  template-press fix, design options to user (scan-policy per regen rule vs
-  case-sensitive substring in regen scans vs entropy-aware exclusion).
+  FIXED+MERGED — template-press PR #82 (6428a9c): opt-in scan = "boundary"
+  on [[regenerate]], applied inside the hunt so separator/case variants
+  stay caught (codex P1 catch); E2E forced re-press passes exit 0.
 - **PROBLEM-23** — low — template-press: the regen-failure path prints only
   the error banner and summary counts; `report.skipped` (which carries the
   exact per-file reason, e.g. the PROBLEM-22 scan hit) is printed only on

--- a/docs/research/0004-template-press-dogfood-log.md
+++ b/docs/research/0004-template-press-dogfood-log.md
@@ -415,11 +415,13 @@ no known-gap bucket remains. Numbering continues at PROBLEM-21.
   wrapped text. Proven fix: regenerate, not rewrite — running the
   documented `uv run pytest tests/cli/test_help_snapshots.py
   --snapshot-update` in the instance turns 2 failed into 11 passed.
-  Disposition: blueprint — declare the `.ambr` under `[[regenerate]]` in
-  press-rules.toml (press-native: identity-dependent generated artifacts
-  regenerate). Caveat to evaluate: the command needs the fork's uv env
-  (first run syncs deps, may need network) inside the press's
-  deny-by-default command env.
+  Disposition: ACCEPTED with fallback — the documented post-press step in
+  docs/POST_INIT.md (snapshot update + full-tree format; landed PR #519).
+  The press-native `[[regenerate]]` declaration was proven to work in the
+  real press (empirical run: exit 0, fresh `.ambr`) but is BLOCKED on
+  template-press#81 — the hermetic-verify exemption cap covers only
+  uv.lock/bun.lock, so declaring it makes `press verify` structurally
+  exit 1 (PROBLEM-28). Revisit when #81 lands.
 - **PROBLEM-21** — low — blueprint: press control files are not rewritten by
   design, so identity tokens embedded in `press/press-rules.toml` COMMENTS
   ship stale into every pressed fork (the G3 comment named the app token

--- a/docs/research/0004-template-press-dogfood-log.md
+++ b/docs/research/0004-template-press-dogfood-log.md
@@ -405,7 +405,8 @@ no known-gap bucket remains. Numbering continues at PROBLEM-21.
   exact per-file reason, e.g. the PROBLEM-22 scan hit) is printed only on
   the success path (`cli.py` ~471 vs ~575). Diagnosing PROBLEM-22 required
   monkeypatching a spy around `execute_regenerations`. Disposition:
-  template-press fix — print skipped entries on the failure path too.
+  FIXED+MERGED — template-press PR #82: the failure path now prints the
+  skipped entries.
 - **PROBLEM-24** — med — blueprint: CLI help-snapshot tests (WL-023, syrupy
   `.ambr`) fail in a pressed fork whenever the app name changes length —
   the press rewrites snapshot text faithfully, but argparse/click re-wraps

--- a/projects/P05-template-press-v34-dogfood-conform.md
+++ b/projects/P05-template-press-v34-dogfood-conform.md
@@ -1,4 +1,4 @@
-## [~] Project P05: Template-press v3.4 dogfood & conform (v1.0.0)
+## [x] Project P05: Template-press v3.4 dogfood & conform (v1.0.0)
 **Goal/Requirement**: Test template-press main @ bd52085 against this repo and
 bring this repo's press config in sync — verify exit 0 via declarations, a
 rebranded instance passes its own checks, and an instance publishes to a
@@ -22,7 +22,7 @@ generated projects, so this link resolves only in the blueprint itself)
 - [x] [P05-T07] Round-1 PR merged; verify green from fresh main clone
 - [x] [P05-TS03] Local rebrand battery passes (dry-run/apply/re-press/check-tools/instance checks)
 - [x] [P05-T08] Instance published to throwaway repo; CI triaged (user-gated)
-- [ ] [P05-T09] Close-out: dispositions, cleanup, report
+- [x] [P05-T09] Close-out: dispositions, cleanup, report
 
 ### Deliverable
 ```bash

--- a/projects/P05-template-press-v34-dogfood-conform.md
+++ b/projects/P05-template-press-v34-dogfood-conform.md
@@ -1,4 +1,7 @@
-## [x] Project P05: Template-press v3.4 dogfood & conform (v1.0.0)
+# P05 — Template-press v3.4 dogfood & conform
+
+**Status:** `[x]` complete (v1.0.0)
+
 **Goal/Requirement**: Test template-press main @ bd52085 against this repo and
 bring this repo's press config in sync — verify exit 0 via declarations, a
 rebranded instance passes its own checks, and an instance publishes to a


### PR DESCRIPTION
Campaign close-out (spec §4 Phase 5 / plan Task 14).

- PROBLEM-22/-23 dispositions → FIXED+MERGED (template-press PR #82, main @ 6428a9c: opt-in `scan = "boundary"` applied inside the hunt; failure path prints skipped reasons).
- Final gate re-pin + result logged: fresh clones, blueprint main @ 8ed30c3 vs template-press main @ 6428a9c — `press verify` and `press check-tools` both exit 0.
- P05 flipped to `[x]` (trunk + project file); every Run 4 problem (21–28) carries a final disposition.
- Follow-ups recorded in the log: template-press#80 ([[remove]] mechanism), #81 (verify exemption cap); blueprint adopts `scan = "boundary"` only after the next template-press release (the key is unknown to v3.4.0); full conform (init/ retirement) is the next campaign per the scope-gate decision.

https://claude.ai/code/session_016oYMBMYRU8C5yhdCNQcnpi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/smorinlabs/codesmith/py-launch-blueprint/pr/520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789542186&installation_model_id=425421&pr_number=520&repository=smorinlabs%2Fpy-launch-blueprint&return_to=https%3A%2F%2Fgithub.com%2Fsmorinlabs%2Fpy-launch-blueprint%2Fpull%2F520&signature=f0fa3a9515f7697aef670cc41e79df60192badd60ed576eb778ba2fa078ab457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Recorded successful final verification for the template-press and check-tools workflow.
  * Confirmed campaign exit criteria and documented the resolution of the regenerated-output boundary scanning issue.
  * Marked Project P05 and its close-out task as completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->