### PR TITLE
docs(projects): close out p06 full-conform campaign

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -27,7 +27,7 @@ file by hand — see Conventions.
 | P03 | `[~]` | [Type Precision Uplevel](projects/P03-type-precision-uplevel.md) — eliminate leaking/overly-general types + verified ty rule promotions + scoped ruff ANN, from a Fable×Codex two-lens audit |
 | P04 | `[x]` | [Py-API Boundary Validation](projects/P04-py-api-boundary-validation.md) — validate Py-API responses at the edge with Pydantic; silent drift → APIError |
 | P05 | `[x]` | [Template-press v3.4 dogfood & conform](projects/P05-template-press-v34-dogfood-conform.md) — press/ config from scratch, verify to declarations-only green, rebrand + publish an instance; findings → Run 4 PROBLEM-NN |
-| P06 | `[~]` | [Full conform — retire the embedded engine](projects/P06-full-conform.md) — delete init/, CI cutover to press verify, v3.6.0 config upgrade ([[remove]], verify_exempt, scan=boundary); closes #423 |
+| P06 | `[x]` | [Full conform — retire the embedded engine](projects/P06-full-conform.md) — delete init/, CI cutover to press verify, v3.6.0 config upgrade ([[remove]], verify_exempt, scan=boundary); closes #423 |
 
 ## Conventions
 

--- a/docs/research/0004-template-press-dogfood-log.md
+++ b/docs/research/0004-template-press-dogfood-log.md
@@ -489,3 +489,18 @@ released uvx for CI/hooks — release in flight). Base: origin/main @ e36ecb9.
   file joins the [[remove]] set; instance re-check green (277+15 pass).
   Reference sweep found no other breaking holders (Justfile recipe and a
   lint-exclude are no-ops in forks).
+
+### Merge & post-merge gates
+
+| time (UTC) | step | command / action | outcome |
+|---|---|---|---|
+| 2026-08-17 | merge | PR #521 via merge queue (merge commit 986eafa7); branch protection required contexts updated to press-verify beforehand | MERGED; init/ engine gone from main (30 files) |
+| 2026-08-17 | fresh-main gate | fresh clone of main → `uvx --from 'template-press>=3.6.0' press verify` and `press check-tools` | PASS: both exit 0 against the released press — no local template-press checkout involved |
+| 2026-08-17 | close-out | #423 auto-closed by the merge; P06 flipped to `[x]` (trunk + project file) | campaign complete |
+
+**Run 5 verdict.** Full conform achieved: the blueprint's only rebrand
+engine is the released template-press (>= 3.6.0 from PyPI); drift
+detection is `press verify` in CI (press-verify.yml), hooks (lefthook
+pre-push), and the fork's own CI (the workflow ships). One new finding
+(PROBLEM-29, fixed in-flight). Cumulative campaign findings: PROBLEM-21
+through PROBLEM-29, all dispositioned.

--- a/projects/P06-full-conform.md
+++ b/projects/P06-full-conform.md
@@ -1,6 +1,6 @@
 # P06 — Full conform: retire the embedded engine
 
-**Status:** `[~]` in progress (v1.0.0)
+**Status:** `[x]` completed (v1.0.0) — merged as PR #521 (986eafa7), 2026-08-17
 
 Delete the embedded init/ engine and everything that polices it; cut CI
 drift detection over to press verify; upgrade the press config to the
@@ -9,16 +9,16 @@ docs/superpowers/specs/2026-08-17-full-conform-design.md (blueprint-only
 history — removed in generated projects). Closes #423.
 
 ### Tests & Tasks
-- [ ] [P06-T01] Press-config upgrade (scan=boundary, snapshot regen +
+- [x] [P06-T01] Press-config upgrade (scan=boundary, snapshot regen +
       verify_exempt, [[remove]] set) — verify exit 0 on v3.6.0
-- [ ] [P06-T02] Guard relocation (scripts/guard.sh, 3 conditions) + new
+- [x] [P06-T02] Guard relocation (scripts/guard.sh, 3 conditions) + new
       guard test suite + Justfile re-point
-- [ ] [P06-T03] CI cutover: press-verify.yml added; blueprint-guard.yml +
+- [x] [P06-T03] CI cutover: press-verify.yml added; blueprint-guard.yml +
       init-integration.yml deleted; lefthook gates swapped
-- [ ] [P06-T04] Delete init/; Justfile recipes; AGENTS.md + skill +
+- [x] [P06-T04] Delete init/; Justfile recipes; AGENTS.md + skill +
       POST_INIT rewrites
-- [ ] [P06-TS01] just check green with no init steps; press verify +
+- [x] [P06-TS01] just check green with no init steps; press verify +
       check-tools exit 0 (branch and fresh main)
-- [ ] [P06-TS02] Acceptance re-press: pressed instance passes
+- [x] [P06-TS02] Acceptance re-press: pressed instance passes
       make check + just setup + just check with zero P05-class hand-fixes
-- [ ] [P06-T05] Close-out: Run 5 log, #423 closed, cleanup with user
+- [x] [P06-T05] Close-out: Run 5 log, #423 closed, cleanup with user


### PR DESCRIPTION
Close-out for the P06 full-conform campaign (PR #521, merge 986eafa7; issue #423).

- Dogfood log Run 5: merge + post-merge gate rows and the run verdict — fresh-main clone passes `uvx --from 'template-press>=3.6.0' press verify` and `press check-tools` (both exit 0).
- `PROJECTS.md` trunk row and `projects/P06-full-conform.md`: P06 → `[x]`, all tasks checked, merge SHA recorded.

Docs-only; no code paths touched.

https://claude.ai/code/session_016oYMBMYRU8C5yhdCNQcnpi

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/smorinlabs/codesmith/py-launch-blueprint/pr/522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789587653&installation_model_id=425421&pr_number=522&repository=smorinlabs%2Fpy-launch-blueprint&return_to=https%3A%2F%2Fgithub.com%2Fsmorinlabs%2Fpy-launch-blueprint%2Fpull%2F522&signature=eccc4c4199b4e747eadf4bfa71b45880112d568933a39712295f5623ea62b8d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->